### PR TITLE
added docker manifest release

### DIFF
--- a/.github/workflows/ci-prerelease.yml
+++ b/.github/workflows/ci-prerelease.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Generate distribution sources
         run: make generate-sources
 
-      # - name: Log into Docker.io
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{secrets.OHAI_DOCKER_HUB_ID}}
-      #     password:  ${{secrets.OHAI_DOCKER_HUB_PASSWORD}}
+      - name: Log into Docker.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_HUB_ID}}
+          password:  ${{secrets.DOCKER_HUB_PASSWORD}}
 
       - uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types:
+      - released
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: release
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set and validate distribution name and version
+        run: .github/workflows/scripts/set_version.sh
+
+      - name: Log into Docker.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_HUB_ID}}
+          password:  ${{secrets.DOCKER_HUB_PASSWORD}}
+
+      - name: Publish docker manifest
+        run: .github/workflows/scripts/docker_manifest_release.sh -i newrelic/${{env.NR_DISTRO}} -v ${{env.NR_VERSION}}

--- a/.github/workflows/scripts/docker_manifest_release.sh
+++ b/.github/workflows/scripts/docker_manifest_release.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This script will create a new manifest from an existing -rc.
+# During the pre-release process we tag all the images using -rc suffix which is not required for the released images.
+
+set -e
+
+print_usage() {
+  printf -- "Usage: %s\n" "$(basename "${0}")"
+  printf -- "-i: Docker image name\n"
+  printf -- "-v: Version of the release\n"
+  printf -- "-h: Print help page\n"
+}
+
+while getopts 'i:v:ph' flag
+do
+    case "${flag}" in
+        h)
+          print_usage
+          exit 0
+        ;;
+        i)
+         image_name="${OPTARG}"
+         continue
+        ;;
+        v)
+         version="${OPTARG}"
+         continue
+        ;;
+        *)
+          print_usage
+          exit 1
+        ;;
+    esac
+done
+
+# Get the list of docker images contained by the rc manifest.
+images=$(docker manifest inspect "${image_name}":"${version}"-rc | jq --arg image "${image_name}" '.manifests[] | ($image+"@"+.digest)' | tr -d \")
+
+printf "Images:\n%s\n" "${images}"
+
+# Create and push a two new manifests latest and versioned without -rc suffix.
+docker manifest create "${image_name}:latest" $images
+docker manifest create "${image_name}:${version}" $images
+
+docker manifest push "${image_name}:latest"
+docker manifest push "${image_name}:${version}"

--- a/.github/workflows/scripts/set_version.sh
+++ b/.github/workflows/scripts/set_version.sh
@@ -23,7 +23,9 @@ fi
 printf "Distribution name: %s, Version name: %s\n" "${distro}" "${version}"
 
 # Set the variables for later use in the GHA pipeline
-echo "NR_DISTRO=${distro}"; echo "NR_VERSION=${version}"; echo "NR_RELEASE_TAG=${tag}"  >> "$GITHUB_ENV"
+echo "NR_DISTRO=${distro}" >> "$GITHUB_ENV"
+echo "NR_VERSION=${version}" >> "$GITHUB_ENV"
+echo "NR_RELEASE_TAG=${tag}" >> "$GITHUB_ENV"
 
 # Assert manifest distro and version
 manifest_file="./distributions/${distro}/manifest.yaml"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,8 +56,7 @@ dockers:
       goarch: amd64
       dockerfile: distributions/nr-otel-collector/Dockerfile
       image_templates:
-        - newrelic/opentelemetry-collector-releases/nr-otel-collector:{{ .Version }}-amd64
-        - newrelic/opentelemetry-collector-releases/nr-otel-collector:latest-amd64
+        - newrelic/nr-otel-collector{{ .Version }}-rc-amd64
       extra_files:
         - configs/nr-otel-collector.yaml
       build_flag_templates:
@@ -73,8 +72,7 @@ dockers:
       goarch: arm64
       dockerfile: distributions/nr-otel-collector/Dockerfile
       image_templates:
-        - newrelic/opentelemetry-collector-releases/nr-otel-collector:{{ .Version }}-arm64
-        - newrelic/opentelemetry-collector-releases/nr-otel-collector:latest-arm64
+        - newrelic/nr-otel-collector{{ .Version }}-rc-arm64
       extra_files:
         - configs/nr-otel-collector.yaml
       build_flag_templates:
@@ -87,14 +85,10 @@ dockers:
         - --label=org.opencontainers.image.source={{.GitURL}}
       use: buildx
 docker_manifests:
-    - name_template: newrelic/opentelemetry-collector-releases/nr-otel-collector:{{ .Version }}
+    - name_template: newrelic/nr-otel-collector{{ .Version }}-rc
       image_templates:
-        - newrelic/opentelemetry-collector-releases/nr-otel-collector:{{ .Version }}-amd64
-        - newrelic/opentelemetry-collector-releases/nr-otel-collector:{{ .Version }}-arm64
-    - name_template: newrelic/opentelemetry-collector-releases/nr-otel-collector:latest
-      image_templates:
-        - newrelic/opentelemetry-collector-releases/nr-otel-collector:latest-amd64
-        - newrelic/opentelemetry-collector-releases/nr-otel-collector:latest-arm64
+        - newrelic/nr-otel-collector{{ .Version }}-rc-amd64
+        - newrelic/nr-otel-collector{{ .Version }}-rc-arm64
 
 publishers:
   - name: GH Publisher


### PR DESCRIPTION
This PR will add the feature of creating docker images tagged as -rc on pre-release and later on the release a new manifest would be pushed without the -rc

The approach is to let goreleaser publishing the docker images and manifest with -rc suffix

Later on the release a new manifest would be pushed without -rc suffix