### PR TITLE
NR-95230 allow to run NRDOT as root

### DIFF
--- a/.github/workflows/ci-goreleaser.yml
+++ b/.github/workflows/ci-goreleaser.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.19.4'
+          go-version: '~1.19.8'
           check-latest: true
 
       - name: Generate the sources

--- a/.github/workflows/ci-prerelease.yml
+++ b/.github/workflows/ci-prerelease.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '~1.19.4'
+          go-version: '~1.19.8'
           check-latest: true
 
       - name: Generate distribution sources

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.19.4'
+          go-version: '~1.19.8'
           check-latest: true
 
       - name: Verify build

--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -2,7 +2,7 @@ dist:
   module: github.com/newrelic/opentelemetry-collector-releases/nr-otel-collector
   name: nr-otel-collector
   description: New Relic OpenTelemetry Collector
-  version: 0.0.1
+  version: 0.0.2
   output_path: ./_build
   otelcol_version: 0.77.0
 

--- a/distributions/nr-otel-collector/nr-otel-collector.service
+++ b/distributions/nr-otel-collector/nr-otel-collector.service
@@ -8,8 +8,6 @@ ExecStart=/usr/bin/nr-otel-collector $OTELCOL_OPTIONS
 KillMode=mixed
 Restart=on-failure
 Type=simple
-User=nr-otel-collector
-Group=nr-otel-collector
 
 [Install]
 WantedBy=multi-user.target

--- a/distributions/nr-otel-collector/nr-otel-collector.service
+++ b/distributions/nr-otel-collector/nr-otel-collector.service
@@ -8,6 +8,8 @@ ExecStart=/usr/bin/nr-otel-collector $OTELCOL_OPTIONS
 KillMode=mixed
 Restart=on-failure
 Type=simple
+User=nr-otel-collector
+Group=nr-otel-collector
 
 [Install]
 WantedBy=multi-user.target

--- a/distributions/nr-otel-collector/postinstall.sh
+++ b/distributions/nr-otel-collector/postinstall.sh
@@ -15,6 +15,10 @@
 # limitations under the License.
 
 if command -v systemctl >/dev/null 2>&1; then
+    if [ "$NRDOT_MODE" = "ROOT" ]; then
+        sed -i "/User=nr-otel-collector/d" /lib/systemd/system/nr-otel-collector.service
+        sed -i "/Group=nr-otel-collector/d" /lib/systemd/system/nr-otel-collector.service
+    fi
     systemctl enable nr-otel-collector.service
     if [ -f /etc/nr-otel-collector/config.yaml ]; then
         systemctl start nr-otel-collector.service

--- a/distributions/nr-otel-collector/postinstall.sh
+++ b/distributions/nr-otel-collector/postinstall.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 if command -v systemctl >/dev/null 2>&1; then
-    if [ "$NRDOT_MODE" = "ROOT" ]; then
+    if [ "${NRDOT_MODE}" = "ROOT" ]; then
         sed -i "/User=nr-otel-collector/d" /lib/systemd/system/nr-otel-collector.service
         sed -i "/Group=nr-otel-collector/d" /lib/systemd/system/nr-otel-collector.service
     fi

--- a/distributions/nr-otel-collector/preinstall.sh
+++ b/distributions/nr-otel-collector/preinstall.sh
@@ -13,5 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-getent passwd nr-otel-collector >/dev/null || useradd --system --user-group --no-create-home --shell /sbin/nologin nr-otel-collector

--- a/distributions/nr-otel-collector/preinstall.sh
+++ b/distributions/nr-otel-collector/preinstall.sh
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 # Create the user if NRDOT_MODE is not set to root
-if [ "$NRDOT_MODE" != "ROOT" ]; then
+if [ "${NRDOT_MODE}" != "ROOT" ]; then
   getent passwd nr-otel-collector >/dev/null || useradd --system --user-group --no-create-home --shell /sbin/nologin nr-otel-collector
 fi

--- a/distributions/nr-otel-collector/preinstall.sh
+++ b/distributions/nr-otel-collector/preinstall.sh
@@ -13,3 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Create the user if NRDOT_MODE is not set to root
+if [ "$NRDOT_MODE" != "ROOT" ]; then
+  getent passwd nr-otel-collector >/dev/null || useradd --system --user-group --no-create-home --shell /sbin/nologin nr-otel-collector
+fi

--- a/test/packaging/ansible/installation-pinned.yaml
+++ b/test/packaging/ansible/installation-pinned.yaml
@@ -5,9 +5,7 @@
   become: true
   gather_facts: yes
   vars:
-    # This is the version of the agent that will be installed.
-    # It is set by the CI.
-    target_version: "{{ lookup('ansible.builtin.env', 'NRDOT_VERSION') }}"
+    nrdot_version: "{{ lookup('ansible.builtin.env', 'NRDOT_VERSION') }}"
 
   pre_tasks:
     - name: Update package repositories
@@ -29,7 +27,7 @@
           vars:
             distribution: "nr-otel-collector"
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-            target_version: "{{ target_version }}"
+            target_version: "{{ nrdot_version }}"
             collector_otlp_endpoint: "staging-otlp.nr-data.net:4317"
 
         - name: Assert version
@@ -38,7 +36,7 @@
           vars:
             target_versions:
               - exec: "nr-otel-collector --version"
-                version: "{{ target_version }}"
+                version: "{{ nrdot_version }}"
 
         - name: assert ownership
           include_tasks: ./custom_tasks/assert_ownership.yml

--- a/test/packaging/ansible/installation-pinned.yaml
+++ b/test/packaging/ansible/installation-pinned.yaml
@@ -4,6 +4,10 @@
   hosts: testing_hosts_linux
   become: true
   gather_facts: yes
+  vars:
+    # This is the version of the agent that will be installed.
+    # It is set by the CI.
+    target_version: "{{ lookup('ansible.builtin.env', 'NRDOT_VERSION') }}"
 
   pre_tasks:
     - name: Update package repositories
@@ -25,7 +29,7 @@
           vars:
             distribution: "nr-otel-collector"
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-            target_version: "{{ lookup('ansible.builtin.env', 'NRDOT_VERSION') }}"
+            target_version: "{{ target_version }}"
             collector_otlp_endpoint: "staging-otlp.nr-data.net:4317"
 
         - name: Assert version
@@ -34,12 +38,12 @@
           vars:
             target_versions:
               - exec: "nr-otel-collector --version"
-                version: "{{ lookup('ansible.builtin.env', 'NRDOT_VERSION') }}"
+                version: "{{ target_version }}"
 
         - name: assert ownership
           include_tasks: ./custom_tasks/assert_ownership.yml
           vars:
-            ownership_process: "root"
+            ownership_process: "{{ 'root' if install_mode == 'ROOT' else 'nr-otel-collector' }}"
             ownership_files: "root"
 
       always:

--- a/test/packaging/ansible/installation-pinned.yaml
+++ b/test/packaging/ansible/installation-pinned.yaml
@@ -6,6 +6,7 @@
   gather_facts: yes
   vars:
     nrdot_version: "{{ lookup('ansible.builtin.env', 'NRDOT_VERSION') }}"
+    process_user: "{{ 'root' if (install_mode is defined and install_mode == 'ROOT') else 'nr-otel-collector' }}"
 
   pre_tasks:
     - name: Update package repositories
@@ -24,6 +25,9 @@
         - name: NR Otel Distribution
           include_role:
             name: caos.ansible_roles.nr_otel_distribution
+            apply:
+              environment:
+                NRDOT_MODE: "{{ 'ROOT' if (install_mode is defined and install_mode == 'ROOT') | default(omit) }}"
           vars:
             distribution: "nr-otel-collector"
             repo_endpoint: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
@@ -41,7 +45,7 @@
         - name: assert ownership
           include_tasks: ./custom_tasks/assert_ownership.yml
           vars:
-            ownership_process: "{{ 'root' if install_mode == 'ROOT' else 'nr-otel-collector' }}"
+            ownership_process: "{{ process_user }}"
             ownership_files: "root"
 
       always:

--- a/test/packaging/ansible/installation-pinned.yaml
+++ b/test/packaging/ansible/installation-pinned.yaml
@@ -39,7 +39,7 @@
         - name: assert ownership
           include_tasks: ./custom_tasks/assert_ownership.yml
           vars:
-            ownership_process: "nr-otel-collector"
+            ownership_process: "root"
             ownership_files: "root"
 
       always:

--- a/test/packaging/ansible/test.yaml
+++ b/test/packaging/ansible/test.yaml
@@ -3,9 +3,13 @@
 - name: pinned version agent installation
   import_playbook: installation-pinned.yaml
 
-# First version cannot be upgraded from a previous one
-# - name: collector upgrade
-#   import_playbook: upgrade.yaml
+- name: pinned version agent installation with full privileges
+  import_playbook: installation-pinned.yaml
+  vars:
+    install_mode: "ROOT"
+
+- name: collector upgrade
+  import_playbook: upgrade.yaml
 
 - name: agent uninstallation
   import_playbook: uninstallation.yaml


### PR DESCRIPTION
- NR-95230 feat: run as root (systemd default)
- ci: test for process ownership by root
- ci: bump Go to v1.19.8
- feat: bump to 0.0.2
- feat: select privileged or unprivileged install
- style: enclose variable in braces
- fix: nrdot version var name
- feat: configurable installation-pinned role
