### PR TITLE
[NR-120689] disable prometheus normalization feature-gate by default

### DIFF
--- a/distributions/nr-otel-collector/Dockerfile
+++ b/distributions/nr-otel-collector/Dockerfile
@@ -10,5 +10,5 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --chmod=755 nr-otel-collector /nr-otel-collector
 COPY configs/nr-otel-collector-agent.yaml /etc/nr-otel-collector/config.yaml
 ENTRYPOINT ["/nr-otel-collector"]
-CMD ["--config", "/etc/nr-otel-collector/config.yaml"]
+CMD ["--config", "/etc/nr-otel-collector/config.yaml", "--feature-gates=-pkg.translator.prometheus.NormalizeName"]
 EXPOSE 4317 55678 55679

--- a/distributions/nr-otel-collector/nr-otel-collector.conf
+++ b/distributions/nr-otel-collector/nr-otel-collector.conf
@@ -6,4 +6,7 @@ NEW_RELIC_MEMORY_LIMIT_MIB=100
 
 # Command-line options for the nr-otel-collector service.
 # Run `/usr/bin/nr-otel-collector --help` to see all available options.
-OTELCOL_OPTIONS="--config=/etc/nr-otel-collector/config.yaml"
+#
+# pkg.translator.prometheus.NormalizeName feature-gate is disabled by default to avoid altering prometheus metrics
+# names when reported through non-prometheus exporters.
+OTELCOL_OPTIONS="--config=/etc/nr-otel-collector/config.yaml --feature-gates=-pkg.translator.prometheus.NormalizeName"


### PR DESCRIPTION
It disables the `pkg.translator.prometheus.NormalizeName` feature-gate by default.

## Background information

The feature gate was enabled by default by [reaching the beta state](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20519/files#diff-29db204fdb7feae902a4f6e8e034f2b00d5c515960dfdd124b6e85eb26d81b1eL87) in otelcollector-contrib [v0.76.3](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.76.3). When this feature-gate is enabled prometheus metrics names are renamed to match OTEL conventions [in the prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/a619329714c5ca24b0e9ba2a83025c441cbf35a8/receiver/prometheusreceiver/internal/metricfamily.go#L305) and we would like to avoid this behavior by default.

Additionally, there is an ongoing discussion to consider providing a configuration option (not a feature-gate) to disable the prometheus normalization: [opentelemetry-collector-contrib#21743](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21743).