### PR TITLE
fix: allow override resources with OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/configs/nr-otel-collector-agent-linux.yaml
+++ b/configs/nr-otel-collector-agent-linux.yaml
@@ -179,7 +179,7 @@ processors:
   batch:
 
   resourcedetection:
-    detectors: ["env", "system"]
+    detectors: ["system"]
     system:
       hostname_sources: ["os"]
       resource_attributes:
@@ -193,6 +193,13 @@ processors:
       resource_attributes:
         host.name:
           enabled: false
+
+  # Gives OTEL_RESOURCE_ATTRIBUTES precedence over other sources.
+  # host.id is set from env whenever the collector is orchestrated by NR Agents.
+  resourcedetection/env:
+    detectors: ["env"]
+    timeout: 2s
+    override: true
 
 exporters:
   logging:
@@ -220,24 +227,25 @@ service:
         - transform/host
         - resourcedetection
         - resourcedetection/cloud
+        - resourcedetection/env
         - cumulativetodelta
         - batch
       exporters: [logging, otlphttp]
     logs/host:
       receivers: [filelog]
-      processors: [transform, resourcedetection, resourcedetection/cloud, batch]
+      processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
       exporters: [logging, otlphttp]
     traces:
       receivers: [otlp]
-      processors: [transform, resourcedetection, resourcedetection/cloud, batch]
+      processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
       exporters: [logging, otlphttp]
     metrics:
       receivers: [otlp]
-      processors: [transform, resourcedetection, resourcedetection/cloud, batch]
+      processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
       exporters: [logging, otlphttp]
     logs:
       receivers: [otlp]
-      processors: [transform, resourcedetection, resourcedetection/cloud, batch]
+      processors: [transform, resourcedetection, resourcedetection/cloud, resourcedetection/env, batch]
       exporters: [logging, otlphttp]
 
   extensions: [health_check]


### PR DESCRIPTION
when the collector is orchestrated by the SA , `host.id` resources attribute is calculated on the SA side and passed to the collector through env var OTEL_RESOURCE_ATTRIBUTES. This should override any previous calculated `host.id` so telemetry can be related (entity relation)