### PR TITLE
Add routing connector and processor

### DIFF
--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -6,6 +6,9 @@ dist:
   output_path: ./_build
   otelcol_version: 0.101.0
 
+connectors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.101.0
+  
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.101.0
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.101.0
@@ -28,6 +31,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.101.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.101.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.101.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor v0.101.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.101.0


### PR DESCRIPTION
Add routing connector and routing processor
Both allow users to send data to multiple NR accounts should they need to
Example configuration using routing connector


    exporters:
      logging:
        verbosity: detailed
      otlp/masteraccount:
        endpoint: https://otlp.nr-data.net:4318
        headers:
          api-key: "xxxNRAL"
      otlp/account1:
        endpoint: https://otlp.nr-data.net:4318
        headers:
          api-key: "xxxNRAL"
      otlp/account2:
        endpoint: https://otlp.nr-data.net:4318
        headers:
          api-key: "xxxNRAL"

    connectors:           
      routing/metrics:
        default_pipelines: [metrics/masteraccount]
        error_mode: propagate
        match_once: false
        table:
          - statement: route() where attributes["k8s.namespace.name"] == "account2"
            pipelines: [metrics/account2]

      routing/logs:
        default_pipelines: [logs/masteraccount]
        error_mode: propagate
        match_once: false
        table:
          - statement: route() where attributes["k8s.namespace.name"] == "account2"
            pipelines: [logs/account2]


        metrics:
          receivers:
            - hostmetrics
            - kubeletstats
            - prometheus
          processors:
            - metricstransform/hostmetrics_cpu
            - transform/truncate
            - filter/exclude_cpu_utilization
            - filter/exclude_memory_utilization
            - filter/exclude_memory_usage
            - filter/exclude_filesystem_utilization
            - filter/exclude_filesystem_usage
            - filter/exclude_filesystem_inodes_usage
            - filter/exclude_system_disk
            - filter/exclude_system_paging
            - filter/exclude_network
            - attributes/exclude_system_paging
            - resourcedetection/env
            - resourcedetection/cloudproviders
            - resource
            - k8sattributes
            - attributes/self
            - memory_limiter
            - groupbyattrs
            - batch
          exporters:
            - routing/metrics

        metrics/masteraccount:
          receivers: [routing/metrics] 
          exporters: [otlp/masteraccount]
        metrics/account1:
          receivers: [routing/metrics]
          exporters: [otlp/account1]
        metrics/account2:
          receivers: [routing/metrics]
          exporters: [otlp/account2]

        logs:
          receivers:
            - filelog
          processors:
            - transform/truncate
            - resource
            - k8sattributes
            - batch
            - groupbyattrs
          exporters:
            - routing/logs

        logs/masteraccount:
          exporters: [otlp/masteraccount]
          receivers: [routing/logs]
        logs/account1:
          receivers: [routing/logs]
          exporters: [otlp/account1]
        logs/account2:
          receivers: [routing/logs]
          exporters: [otlp/account2]