### PR TITLE
chore: increase threshold of network packet alert on canary

### DIFF
--- a/test/canaries/alerts/vars.auto.tfvars.dist
+++ b/test/canaries/alerts/vars.auto.tfvars.dist
@@ -374,7 +374,7 @@ conditions = [
   {
     name          = "host receiver network packets receive"
     metric        = "system.network.packets"
-    threshold     = 0
+    threshold     = 2
     duration      = 600
     operator      = "above"
     template_name = "./nrql_templates/single_metric_comparator.tftpl"
@@ -385,7 +385,7 @@ conditions = [
   {
     name          = "host receiver network packets transmit"
     metric        = "system.network.packets"
-    threshold     = 0.6
+    threshold     = 2
     duration      = 600
     operator      = "above"
     template_name = "./nrql_templates/single_metric_comparator.tftpl"


### PR DESCRIPTION
Latest release `0.8.0` triggered the network packet receive/transmit alert for some of the canaries. I didn't found any relevant data on the receiver changelog, and metrics looked to be working Ok so increasing the threshold to avoid new false positive.
<img width="515" alt="image" src="https://github.com/user-attachments/assets/75a72eb0-1572-4609-871e-04e278254748">
