### PR TITLE
fix: Added endpoints to receivers

### DIFF
--- a/configs/nr-otel-collector-gateway.yaml
+++ b/configs/nr-otel-collector-gateway.yaml
@@ -13,7 +13,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:

--- a/configs/nr-otel-collector-gateway.yaml
+++ b/configs/nr-otel-collector-gateway.yaml
@@ -13,6 +13,8 @@ receivers:
   otlp:
     protocols:
       grpc:
+        # To limit exposure to denial of service attacks, change the host in endpoints below from 0.0.0.0 to a specific network interface.
+        # See https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318


### PR DESCRIPTION
The nr-otel-collector only worked when I added endpoints to `grpc` and `http` for the receivers. 