### PR TITLE
fix: force docker@27.3.1 to fix CVE-2024-41110

### DIFF
--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -46,3 +46,6 @@ receivers:
 replaces:
   # See https://github.com/google/gnostic/issues/262
   - github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5
+  # Why: Fixes CVE-2024-41110 introduced by transitive docker dependency brought in by prometheusreceiver
+  # Remove: prometheusreceiver no longer brings in vulnerable docker dependency
+  - github.com/docker/docker v27.0.3+incompatible => github.com/docker/docker v27.3.1+incompatible


### PR DESCRIPTION
### Summary
- Replace ` github.com/docker/docker v27.0.3+incompatible` brought in by `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.108.0` with `github.com/docker/docker v27.3.1+incompatible`
- Building docker image locally and running [trivy](https://github.com/newrelic/opentelemetry-collector-releases/blob/6827ddaf22a5e73804744bc79fc3b401b03a0795/.github/workflows/security.yml#L28) reports issue as resolved
```
➜  ~ trivy image --scanners=vuln --vuln-type=os,library --severity=HIGH,CRITICAL
 --ignore-unfixed newrelic/nr-otel-collector:0.0.0-SNAPSHOT-6f99399-rc-arm64
2024-10-17T13:03:02-07:00	WARN	'--vuln-type' is deprecated. Use '--pkg-types' instead.
2024-10-17T13:03:02-07:00	INFO	[vuln] Vulnerability scanning is enabled
2024-10-17T13:03:02-07:00	INFO	Detected OS	family="alpine" version="3.18.9"
2024-10-17T13:03:02-07:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.18" repository="3.18" pkg_num=19
2024-10-17T13:03:02-07:00	INFO	Number of language-specific files	num=1
2024-10-17T13:03:02-07:00	INFO	[gobinary] Detecting vulnerabilities...

newrelic/nr-otel-collector:0.0.0-SNAPSHOT-6f99399-rc-arm64 (alpine 3.18.9)

Total: 0 (HIGH: 0, CRITICAL: 0)
```

### Context
- Fixing this here for now because a fix in the receiver itself might not be sufficient because it also has prometheus itself as dependency which has no fixed 0.x.x version to this day. The newest 0.54.1 of that major version [still has the vulnerability](https://github.com/prometheus/prometheus/blob/v0.54.1/go.mod#L21), so we would need to not only upgrade the receiver but most likely also prometheus itself or do a major version bump or work with overrides which is unclear if that is even an option in the contrib repo due to the technical debt it introduces. We'll make an effort to fix this upstream in the contrib repo but until we have a clear path forward, this fixes the vulnerability in NRDOT.