### PR TITLE
ci: add workflow to reset stateful test infra

### DIFF
--- a/.github/workflows/clean_test_infra_on_demand.yml
+++ b/.github/workflows/clean_test_infra_on_demand.yml
@@ -1,0 +1,78 @@
+name: 💥 Clean test infra on demand
+
+on:
+  workflow_dispatch:
+    inputs:
+      unique_tag:
+        description: 'Unique tag or prefix'
+        required: true
+      clean_packaging_infra:
+        description: 'Destroy packaging infra?'
+        required: true
+        type: boolean
+        default: false
+      clean_canary_infra:
+        description: 'Destroy canary infra?'
+        required: true
+        type: boolean
+        default: false
+      platform:
+        description: 'Platform prefix for canary ec2 names'
+        required: true
+        type: string
+        default: "linux"
+
+
+jobs:
+  clean-infra:
+    name: Clean infra
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set branch name
+        run: |
+          # Short name for current branch. For PRs, use target branch (base ref)
+          GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          # Is the ref a tag? If so, remove refs/tags/ prefix
+          GIT_BRANCH=${GIT_BRANCH#refs/tags/}
+          echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
+
+      - name: Clean packaging infra
+        uses: newrelic/fargate-runner-action@main
+        if: ${{ input.clean_packaging_infra }}
+        with:
+          aws_region: us-east-2
+          container_make_target: "test/provision-clean TAG_OR_UNIQUE_NAME=otel-${{ inputs.unique_tag }}"
+          ecs_cluster_name: caos_otel_releases
+          task_definition_name: otel-releases
+          cloud_watch_logs_group_name: /ecs/test-prerelease-otel-releases
+          cloud_watch_logs_stream_name: ecs/test-otel-releases
+          aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
+          repo_name: "newrelic/opentelemetry-collector-releases"
+          ref: "${{ env.GIT_BRANCH }}"
+          log_filters: |
+            Destroy\scomplete!
+      - name: Clean canary infra
+        uses: newrelic/fargate-runner-action@main
+        if: ${{ input.clean_canary_infra }}
+        with:
+          aws_region: us-east-2
+          container_make_target: "test/provision-clean TAG_OR_UNIQUE_NAME=otel-canary:${{ inputs.unique_tag }}-${{ inputs.platform }}"
+          ecs_cluster_name: caos_otel_releases
+          task_definition_name: otel-releases
+          cloud_watch_logs_group_name: /ecs/test-prerelease-otel-releases
+          cloud_watch_logs_stream_name: ecs/test-otel-releases
+          aws_vpc_subnet: ${{ secrets.AWS_VPC_SUBNET }}
+          repo_name: "newrelic/opentelemetry-collector-releases"
+          ref: "${{ env.GIT_BRANCH }}"
+          log_filters: |
+            Destroy\scomplete!


### PR DESCRIPTION
### Summary
- Add workflow to destroy packaging and canary testing infrastructure, i.e. EC2 instances launched by terraform scripts, on demand.
- Boolean flag allows destroying only canary or packaging infra. This can be helpful when canary tests were started on demand while the packaging tests were still failing and we don't want to interfere with those parallelized test strains.


### Context
- [Prerelease workflow for 0.8.3](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/11300063884) fails repeatedly for the same reason. In order to rule out the reused EC2 instance as the culprit, we should have a workflow to reset test infrastructure on demand.
- Having this workflow allows maintainers to debug broken workflows without having to have write access to the underlying AWS test account