### PR TITLE
Add permissions to delete workflow

### DIFF
--- a/.github/workflows/clean_test_infra_on_demand.yml
+++ b/.github/workflows/clean_test_infra_on_demand.yml
@@ -22,6 +22,8 @@ on:
         type: string
         default: "linux"
 
+permissions:
+  id-token: write
 
 jobs:
   clean-infra:


### PR DESCRIPTION
### Summary
- Fixing [missing permission](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/11465545111/job/31904219825) for delete workflow