### PR TITLE
chore: Remove all but ubuntu instances in test pipeline

### DIFF
--- a/test/provision/terraform/caos-linux.auto.tfvars.dist
+++ b/test/provision/terraform/caos-linux.auto.tfvars.dist
@@ -1,5 +1,5 @@
 ec2_prefix       = "TAG_OR_UNIQUE_NAME"
-ec2_filters      = ["al-2023", "al-2", "debian-bookworm", "debian-bullseye", "redhat-9.0", "sles-15.4", "centos-stream", "ubuntu22.04", "ubuntu24.04"]
+ec2_filters      = ["ubuntu22.04", "ubuntu24.04"]
 
 ssh_pub_key      = "AAAAB3NzaC1yc2EAAAADAQABAAABAQDH9C7BS2XrtXGXFFyL0pNku/Hfy84RliqvYKpuslJFeUivf5QY6Ipi8yXfXn6TsRDbdxfGPi6oOR60Fa+4cJmCo6N5g57hBS6f2IdzQBNrZr7i1I/a3cFeK6XOc1G1tQaurx7Pu+qvACfJjLXKG66tHlaVhAHd/1l2FocgFNUDFFuKS3mnzt9hKys7sB4aO3O0OdohN/0NJC4ldV8/OmeXqqfkiPWcgPx3C8bYyXCX7QJNBHKrzbX1jW51Px7SIDWFDV6kxGwpQGGBMJg/k79gjjM+jhn4fg1/VP/Fx37mAnfLqpcTfiOkzSE80ORGefQ1XfGK/Dpa3ITrzRYW8xlR caos-dev-arm"
 pvt_key          = "~/.ssh/caos-dev-arm.cer"


### PR DESCRIPTION
We're seeing spurious failures while provisioning some of the ec2 instances, we're reducing the scope for now while we iron out the details of what os/arch we need to be testing for.