### PR TITLE
release 0.8.5

### DIFF
--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -2,7 +2,7 @@ dist:
   module: github.com/newrelic/opentelemetry-collector-releases/nr-otel-collector
   name: nr-otel-collector
   description: New Relic OpenTelemetry Collector
-  version: 0.8.4
+  version: 0.8.5
   output_path: ./_build
   otelcol_version: 0.108.0
 


### PR DESCRIPTION
### Why
`0.8.4` was cut without a version bump associated so we're bumping the release to `0.8.5`