### PR TITLE
chore: delete SECURITY.md to use org default

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,0 @@
-# Reporting Security Vulnerabilities
-
-New Relic is committed to the security of our customers and your data. We believe that engaging with security researchers through our coordinated disclosure program is an important means to achieve our security goals.
-
-If you believe you have found a security vulnerability in one of our products or websites, we welcome and greatly appreciate you reporting it to New Relic's coordinated disclosure program.  Please see our [website for more information on how to report a vulnerability](https://docs.newrelic.com/docs/security/new-relic-security/data-privacy/reporting-security-vulnerabilities).


### PR DESCRIPTION
### Summary
- Replaces https://github.com/newrelic/opentelemetry-collector-releases/pull/126 as I couldn't rebase that fork to make it pass tests.
- Removing the SECURITY.md [should](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository) just lead to us defaulting to the default one for the newrelic org.