### PR TITLE
fix: infer previous tag during prerelease workflow

### DIFF
--- a/.github/workflows/ci-prerelease.yml
+++ b/.github/workflows/ci-prerelease.yml
@@ -106,7 +106,6 @@ jobs:
     needs: [packaging-tests]
     with:
       TAG: ${{ github.ref_name }}
-      PREVIOUS_TAG: "latest"
       PLATFORM: "linux"
       IMAGE: "newrelic/nr-otel-collector" #should be changed after pre-release
     secrets:

--- a/.github/workflows/component_canaries.yml
+++ b/.github/workflows/component_canaries.yml
@@ -16,8 +16,10 @@ on:
         required: true
         type: string
       PREVIOUS_TAG:
-        required: true
+        required: false
         type: string
+        # by default set_version.sh will infer previous tag based on TAG
+        default: ''
       PLATFORM:
         required: true
         type: string


### PR DESCRIPTION
### Summary
- No longer supply PREVIOUS_TAG in prerelease workflow and default to empty string instead so that [set_versions.sh](https://github.com/newrelic/opentelemetry-collector-releases/blob/b3e88ea15f7fb80d9116cd36f5c53643c9f46aeb/.github/workflows/scripts/set_version.sh#L13) can infer the previous tag as using `latest` always leads to [an error](https://github.com/newrelic/opentelemetry-collector-releases/blob/b3e88ea15f7fb80d9116cd36f5c53643c9f46aeb/.github/workflows/scripts/set_version.sh#L32), see example [from 0.8.5 prerelease](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/11507504187/job/32085605669#step:5:17).
- For any situation out of the ordinary (inferred previous tag isn't the one we want to compare with), we can always destroy canaries and alerts with on demand workflows and use the [on demand canary provision](https://github.com/newrelic/opentelemetry-collector-releases/blob/abcae426061609bdf8f2005cf5d94a5931f874e6/.github/workflows/canaries_on_demand.yml#L23) workflow to choose a custom previous tag.