### PR TITLE
fix: Adjust canary alerting thresholds

### DIFF
--- a/test/canaries/alerts/vars.auto.tfvars.dist
+++ b/test/canaries/alerts/vars.auto.tfvars.dist
@@ -7,7 +7,7 @@ conditions = [
   {
     name          = "host receiver cpu.utilization"
     metric        = "system.cpu.utilization"
-    threshold     = 0.0001
+    threshold     = 0.001
     duration      = 600
     operator      = "above"
     template_name = "./nrql_templates/single_metric_comparator.tftpl"
@@ -352,7 +352,7 @@ conditions = [
   {
     name          = "host receiver network io receive"
     metric        = "system.network.io"
-    threshold     = 50
+    threshold     = 200
     duration      = 600
     operator      = "above"
     template_name = "./nrql_templates/single_metric_comparator.tftpl"
@@ -374,7 +374,7 @@ conditions = [
   {
     name          = "host receiver network packets receive"
     metric        = "system.network.packets"
-    threshold     = 2
+    threshold     = 5
     duration      = 600
     operator      = "above"
     template_name = "./nrql_templates/single_metric_comparator.tftpl"
@@ -385,7 +385,7 @@ conditions = [
   {
     name          = "host receiver network packets transmit"
     metric        = "system.network.packets"
-    threshold     = 2
+    threshold     = 5
     duration      = 600
     operator      = "above"
     template_name = "./nrql_templates/single_metric_comparator.tftpl"


### PR DESCRIPTION
### Summary
- Goal is to make canary alerts going off a more reliable signal prompting actual investigation instead of just confirming false positives. We'll do this by adjusting alerting thresholds to account for volatile signals and thus inherent discrepancies between the previous/current canaries scraping the same host metrics as the scraping will not be perfectly aligned.
- In order to make an informed decision about more appropriate thresholds, I analyzed alerts going off for the latest canary iteration.

### Alert analysis
- [Alerts in stable state (post deployment) of canaries 0.8.5 vs 0.8.4](https://staging.onenr.io/02wdvL5p9jE) (for reference [including startup](https://staging.onenr.io/08woXpvb5Rx))
- For reference [scrape frequency is 20s](https://github.com/newrelic/opentelemetry-collector-releases/blob/e09d06505120830cb3faa8027639671b60158bfd/test/canaries/templates/nr-otel-collector-agent.yml.j2#L19)
- host receiver network io receive [on both ubuntu distros and archs](https://staging.onenr.io/0BR6vyxA0RO)
	- alert analysis to rule out any substantial issues
		- arm64 ubuntu24: [shows exactly 10 minutes](https://staging.onenr.io/08jqWGWNGwl) where 0.8.5 observes a slightly higher baseline
		- amd64 ubuntu24: [prev and current crossing](https://staging.onenr.io/0ZQWb6blajW) but keeping absolute value difference high enough to cause alert
		- arm64 ubuntu22: prev [did not observe initial spike](https://staging.onenr.io/0ERz3b3KZjr), after that almost perfectly aligned
		- amd64 ubuntu22: [almost perfectly aligned](https://staging.onenr.io/0gR7nYnNWwo)
	- [transmit threshold is already set to 200](https://github.com/newrelic/opentelemetry-collector-releases/blob/6a3a0843a20debe8c7aec995661b02ea4196b96c/test/canaries/alerts/vars.auto.tfvars.dist#L366) and that threshold would have prevented all of the following alerts, so setting it from 50 to 200
- host receiver cpu util (on [22.04 amd64](https://staging.onenr.io/02R5ApaW1Rb))
	- adjustment from 0.0001 to 0.001 based on the fact that [the observed fluctuation](https://staging.onenr.io/0LwGLYAoKR6) for the single violation seems not to be indicative of any real issue (previous and current hover around the same value)
- host receiver network packets transmit (on [24.04 arm64](https://staging.onenr.io/08jqWGvMdwl))
	- [unclear how we could see a stable difference for ~20min](https://staging.onenr.io/0dQeVLvG5we)
		- [scraping is done by network interface](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/7500155042a972f3df4350a3077fb1d24b390067/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go#L119C17-L119C34) and [docker compose running both versions](https://github.com/newrelic/opentelemetry-collector-releases/blob/ebc0b82e2f163c9412915ace616808184bc57c51/test/canaries/templates/docker-compose.yml.j2)] specifies no special network. By default [compose uses a single network](https://docs.docker.com/compose/how-tos/networking/) for all containers, so no reason to believe that the two versions are scraping different network interfaces and the [device attribute](https://staging.onenr.io/02R5ApakoRb) is [eth0 for both](https://staging.onenr.io/02R5ApakoRb)
		- [looking at 20s-buckets](https://staging.onenr.io/0kjnLvd7Xwo) (scrape frequency) does show that there are spikes and a constant intercept that are not captured by `previous`. However, given that we are comparing two version (0.8.4 and 0.8.5) that use the exact same `hostmetricreceiver`, this is most likely a flaw in our test environment design rather than a bug in the receiver.
	- as this is most likely a test environment issue (that we not yet fully understand), I suggest bumping threshold from 2 to 5