### PR TITLE
chore: Removing deprecated ballastextension component

### DIFF
--- a/distributions/nr-otel-collector/THIRD_PARTY_NOTICES.md
+++ b/distributions/nr-otel-collector/THIRD_PARTY_NOTICES.md
@@ -285,14 +285,6 @@ Distributed under the following license(s):
 
 
 
-## [go.opentelemetry.io/collector/extension/ballastextension](https://go.opentelemetry.io/collector/extension/ballastextension)
-
-Distributed under the following license(s):
-
-* Apache-2.0
-
-
-
 ## [go.opentelemetry.io/collector/extension/zpagesextension](https://go.opentelemetry.io/collector/extension/zpagesextension)
 
 Distributed under the following license(s):

--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -9,7 +9,6 @@ dist:
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.108.0
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.108.0
-  - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.108.0
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.108.0


### PR DESCRIPTION
Per the [docs](https://pkg.go.dev/go.opentelemetry.io/collector/extension/ballastextension#section-readme) this component has been deprecated in favor of using the `GOMEMLIMIT` envvar.  It's no longer present as of `0.109.0` https://github.com/open-telemetry/opentelemetry-collector/tree/v0.109.0/extension

Currently our helm-charts do not appear to be exposing this config so there should be no issue dropping it: https://github.com/search?q=repo%3Anewrelic%2Fhelm-charts%20memory_ballast&type=code
