### PR TITLE
fix: download trivy db only once per day

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         run: echo "version=$(jq -r '.version' dist/metadata.json)" >> $GITHUB_ENV
 
       - name: Trivy security check
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: "newrelic/nr-otel-collector:${{ env.version }}-rc-amd64"
           format: 'table'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,3 +72,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: "HIGH,CRITICAL"
+        env:
+          # dbs are downloaded async in download_trivy_db.yml
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true

--- a/.github/workflows/component_snyk.yml
+++ b/.github/workflows/component_snyk.yml
@@ -53,7 +53,7 @@ jobs:
           # This data can be any valid JSON from a previous step in the GitHub Action
           payload: |
             {
-              "text": ":rotating_light: Hi CAOS (@hero), critical or high vulnerabilities found in NRDOT, see: https://github.com/newrelic/opentelemetry-collector-releases/security :rotating_light:"
+              "text": ":rotating_light: Hi from your Github Action, vulnerabilities found in NRDOT, see: https://github.com/newrelic/opentelemetry-collector-releases/security :rotating_light:"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook }}

--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -52,6 +52,10 @@ jobs:
           severity: "${{ inputs.severity }}"
           exit-code: "1"
           ignore-unfixed: true
+        env:
+          # dbs are downloaded async in download_trivy_db.yml
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
@@ -67,7 +71,7 @@ jobs:
           # This data can be any valid JSON from a previous step in the GitHub Action
           payload: |
             {
-              "text": ":rotating_light: Hi CAOS (@hero), critical or high vulnerabilities found in NRDOT, see: https://github.com/newrelic/opentelemetry-collector-releases/security :rotating_light:"
+              "text": ":rotating_light: Hi from your Github Action, vulnerabilities found in NRDOT, see: https://github.com/newrelic/opentelemetry-collector-releases/security :rotating_light:"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook }}

--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ ! github.event.schedule }} # Table output
     steps:
       - name: newrelic/nr-otel-collector
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: "${{ inputs.image }}:${{ inputs.tag }}"
           format: "table"
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Sarif newrelic/nr-otel-collector
-        uses: aquasecurity/trivy-action@0.8.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: "${{ inputs.image }}:${{ inputs.tag }}"
           format: "sarif"

--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -33,6 +33,10 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "${{ inputs.severity }}"
+        env:
+          # dbs are downloaded async in download_trivy_db.yml
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
   trivy_scanner_scheduled:
     name: Scheduled Trivy scanner for docker

--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   trivy_scanner:
     name: Trivy scanner for docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ ! github.event.schedule }} # Table output
     steps:
       - name: newrelic/nr-otel-collector
@@ -40,7 +40,7 @@ jobs:
 
   trivy_scanner_scheduled:
     name: Scheduled Trivy scanner for docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event.schedule }} # Upload sarif when running periodically
     steps:
       - name: Checkout

--- a/.github/workflows/download_trivy_db.yml
+++ b/.github/workflows/download_trivy_db.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-trivy-db:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup oras
         uses: oras-project/setup-oras@v1

--- a/.github/workflows/download_trivy_db.yml
+++ b/.github/workflows/download_trivy_db.yml
@@ -1,0 +1,40 @@
+name: Update Trivy Cache
+
+on:
+  schedule:
+    - cron: '0 12 * * *' # Update daily - before scheduled trivy scan
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-trivy-db:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          # try GHCR, fallback to ECR
+          { oras pull ghcr.io/aquasecurity/trivy-db:2 } || { oras pull public.ecr.aws/aquasecurity/trivy-db:2 }
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      # Also recommended by trivy docs for non-java projects as jars could be embedded in unexpected places
+      - name: Download and extract the Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          # try GHCR, fallback to ECR
+          { oras pull ghcr.io/aquasecurity/trivy-java-db:1 } || { oras pull public.ecr.aws/aquasecurity/trivy-java-db:1 }
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,8 @@
 name: . 🕵🏼 Security scanner
 on:
   schedule:
-    # Scheduled to run at 8 a.m on every day-of-week from Monday through Friday.
-    - cron:  '0 8 * * 1-5'
+    # Scheduled to run in the morning (PT) on every day-of-week from Monday through Friday.
+    - cron:  '0 15 * * 1-5'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
### Summary (https://new-relic.atlassian.net/browse/NR-335800)
- Trying to address the GHCR global rate limiting issue ([that affects all users of trivy b/c its a ratelimit on the vendor namespace](https://github.com/orgs/community/discussions/139074)) by combining all of the available fixes, i.e.
    1. Use [oras](https://oras.land/) to [download trivy db only once daily and cache in workspace](https://github.com/aquasecurity/trivy-action/issues/389#issuecomment-2373539982). 
    2. Modified `oras pull ghcr.io/aquasecurity/trivy-db:2` to `{ oras pull ghcr.io/aquasecurity/trivy-db:2 } || { oras pull public.ecr.aws/aquasecurity/trivy-db:2 }` (same for java db download) to enable a fallback to ECR which [also hosts the db](https://github.com/aquasecurity/trivy-action/issues/389#issuecomment-2373539982) but can also be affected by ratelimiting.
- Changed scheduled security run to morning of PT to align with timezone of new owning team
- using ubuntu-22.04 [based on this suggestion](https://github.com/orgs/community/discussions/139074#discussioncomment-10935090). Our rationale was that it might actually pull a different artifact due to different arch/os and therefore be subject to different rate limit - might be a stretch but as there is no real solution yet, we're willing to give it a shot.
- Updating and pinning version of trivy action to newest as of today (0.28.0)

### Misc
- Make slack message more generic (less team-specific)