### PR TITLE
Kbauer/fix syntax errors

### DIFF
--- a/.github/workflows/download_trivy_db.yml
+++ b/.github/workflows/download_trivy_db.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
           # try GHCR, fallback to ECR
-          { oras pull ghcr.io/aquasecurity/trivy-db:2; } || { oras pull public.ecr.aws/aquasecurity/trivy-db:2; }
+          oras pull ghcr.io/aquasecurity/trivy-db:2 || oras pull public.ecr.aws/aquasecurity/trivy-db:2
           tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
           rm db.tar.gz
       - name: Download and extract the Java DB

--- a/.github/workflows/download_trivy_db.yml
+++ b/.github/workflows/download_trivy_db.yml
@@ -23,7 +23,6 @@ jobs:
           { oras pull ghcr.io/aquasecurity/trivy-db:2; } || { oras pull public.ecr.aws/aquasecurity/trivy-db:2; }
           tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
           rm db.tar.gz
-
       - name: Download and extract the Java DB
       # Also recommended by trivy docs for non-java projects as jars could be embedded in unexpected places
         run: |
@@ -32,7 +31,6 @@ jobs:
           { oras pull ghcr.io/aquasecurity/trivy-java-db:1; } || { oras pull public.ecr.aws/aquasecurity/trivy-java-db:1; }
           tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
           rm javadb.tar.gz
-
       - name: Cache DBs
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/download_trivy_db.yml
+++ b/.github/workflows/download_trivy_db.yml
@@ -20,16 +20,16 @@ jobs:
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
           # try GHCR, fallback to ECR
-          { oras pull ghcr.io/aquasecurity/trivy-db:2 } || { oras pull public.ecr.aws/aquasecurity/trivy-db:2 }
+          { oras pull ghcr.io/aquasecurity/trivy-db:2; } || { oras pull public.ecr.aws/aquasecurity/trivy-db:2; }
           tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
           rm db.tar.gz
 
-      # Also recommended by trivy docs for non-java projects as jars could be embedded in unexpected places
       - name: Download and extract the Java DB
+      # Also recommended by trivy docs for non-java projects as jars could be embedded in unexpected places
         run: |
           mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
           # try GHCR, fallback to ECR
-          { oras pull ghcr.io/aquasecurity/trivy-java-db:1 } || { oras pull public.ecr.aws/aquasecurity/trivy-java-db:1 }
+          { oras pull ghcr.io/aquasecurity/trivy-java-db:1; } || { oras pull public.ecr.aws/aquasecurity/trivy-java-db:1; }
           tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
           rm javadb.tar.gz
 


### PR DESCRIPTION
### Summary
- #143 is [causing issues](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/11713709522/job/32626976898), most likely due to some syntax error
```
line 6: syntax error: unexpected end of file
```
- Fixing [potentially invalid block scalars](https://yaml.org/spec/1.2.2/#chapter-8-block-style-productions) by removing unindented newlines following script 
> It is an error if any non-[empty line](https://yaml.org/spec/1.2.2/#empty-lines) does not begin with a number of spaces greater than or equal to the content indentation level.
- According [to the docs](https://www.gnu.org/software/bash/manual/bash.html#Command-Grouping), bash requires a semicolon in `{ }` expressions. zsh is 'smart' enough to ignore that but when testing with bash it actually does cause errors or rather an input prompt, e.g. `{ echo 'foo' }` is invalid