### PR TITLE
chore: Change codeowners to otelcomm

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
 
-* @newrelic/caos
+* @newrelic/otelcomm


### PR DESCRIPTION
Changing codeowners to new owning team [otelcomm](https://github.com/orgs/newrelic/teams/otelcomm)