### PR TITLE
chore: simplify trivy workflow for easier debug

### DIFF
--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -40,7 +40,11 @@ jobs:
 
       - name: Print Trivy scan results # action can't do both table/sarif output, so we just print the sarif file
         run: |
-          cat trivy-results.sarif
+          if [[ -s trivy-results.sarif ]]; then
+            cat trivy-results.sarif
+          else
+            echo "No sarif file found"
+          fi
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         if: ${{ inputs.tag == 'latest' }} # Upload sarif only for latest

--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -22,30 +22,7 @@ jobs:
   trivy_scanner:
     name: Trivy scanner for docker
     runs-on: ubuntu-22.04
-    if: ${{ ! github.event.schedule }} # Table output
     steps:
-      - name: newrelic/nr-otel-collector
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: "${{ inputs.image }}:${{ inputs.tag }}"
-          format: "table"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "${{ inputs.severity }}"
-        env:
-          # dbs are downloaded async in download_trivy_db.yml
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
-
-  trivy_scanner_scheduled:
-    name: Scheduled Trivy scanner for docker
-    runs-on: ubuntu-22.04
-    if: ${{ github.event.schedule }} # Upload sarif when running periodically
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Sarif newrelic/nr-otel-collector
         uses: aquasecurity/trivy-action@0.28.0
         with:
@@ -62,15 +39,15 @@ jobs:
           TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        if: ${{ always() }}
+        uses: github/codeql-action/upload-sarif@v3
+        if: ${{ inputs.tag == 'latest' }} # Upload sarif only for latest
         with:
           sarif_file: "trivy-results.sarif"
 
       - name: Send notification to Slack Workflow
         if: ${{ failure() }}
         id: slack
-        uses: slackapi/slack-github-action@v1.22.0
+        uses: slackapi/slack-github-action@v1.27.0
         with:
           # This data can be any valid JSON from a previous step in the GitHub Action
           payload: |

--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -38,6 +38,9 @@ jobs:
           TRIVY_SKIP_DB_UPDATE: true
           TRIVY_SKIP_JAVA_DB_UPDATE: true
 
+      - name: Print Trivy scan results # action can't do both table/sarif output, so we just print the sarif file
+        run: |
+          cat trivy-results.sarif
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         if: ${{ inputs.tag == 'latest' }} # Upload sarif only for latest


### PR DESCRIPTION
### Summary
- Changing trivy workflow from split logic based on 'scheduled or not' to 'scanning latest or not'. If we're scanning latest, it can upload the results even if we run it manually. This will hopefully allow us to get to the bottom of why the [scheduled scan failed](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/11744528669/job/32719848741) while the  [manually triggered one](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/11728764538) succeeded.
- Removing checkout because the manual run didn't have it and we are just scanning an image that is published to docker hub and we're not using any local config file like some of the [docs](https://github.com/aquasecurity/trivy-action) suggest, so there should be no reason to checkout the repo. We might want to transition to [scanning the locally build image](https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#scan-ci-pipeline) to get PR-level feedback but I would do that in a separate PR.
- Printing the sarif output to have some output to understand potential errors. We could also run trivy again with table format but I ended up going with printing the sarif file to not have to deal with discrepancies between the two runs
