### PR TITLE
chore: print and upload trivy results also on fail

### DIFF
--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -39,6 +39,7 @@ jobs:
           TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Print Trivy scan results # action can't do both table/sarif output, so we just print the sarif file
+        if: ${{ (success() || failure()) && inputs.tag == 'latest' }}
         run: |
           if [[ -s trivy-results.sarif ]]; then
             cat trivy-results.sarif
@@ -47,12 +48,13 @@ jobs:
           fi
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: ${{ inputs.tag == 'latest' }} # Upload sarif only for latest
+        # Upload sarif only for latest
+        if: ${{ (success() || failure()) && inputs.tag == 'latest' }}
         with:
           sarif_file: "trivy-results.sarif"
 
       - name: Send notification to Slack Workflow
-        if: ${{ failure() }}
+        if: ${{ failure() && inputs.tag == 'latest' }}
         id: slack
         uses: slackapi/slack-github-action@v1.27.0
         with:


### PR DESCRIPTION
### Summary
- In order to not skip the print/upload step on a trivy failure, we need to prepend a status check expression, otherwise it defaults to `success()` only ([see docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#failure-with-conditions))
- Added `inputs.tag == 'latest'` conditional to slack step as other tags would only be present in manual runs and we can save us the notification in that case