### PR TITLE
fix: Change webhook type to incoming webhook

### DIFF
--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -65,3 +65,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
### Summary
- #151 fixed the security workflow so that trivy now runs and [prints failure reports](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/11803631347/job/32882015483) properly. Before addressing the fact that it reports 'low' priority CVE even though it's configured not to do so, I wanted to use this opportunity to fix the slack hook cause it's currently not posting messages to the slack channel.
- Based on the docs, it looks like the webhook we received from IT (`https://hooks.slack.com/services/...`) is an [incoming webhook](https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-3-slack-incoming-webhook) instead of a [workflow webhook](https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-1-slack-workflow-builder), so the config that CAOS used needs to be slightly adjusted by adding `SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK`