### PR TITLE
fix: exclude <= medium severity from sarif output

### DIFF
--- a/.github/workflows/component_trivy.yml
+++ b/.github/workflows/component_trivy.yml
@@ -33,6 +33,7 @@ jobs:
           severity: "${{ inputs.severity }}"
           exit-code: "1"
           ignore-unfixed: true
+          limit-severities-for-sarif: true
         env:
           # dbs are downloaded async in download_trivy_db.yml
           TRIVY_SKIP_DB_UPDATE: true


### PR DESCRIPTION
### Summary
- Turns out sarif format does not respect the `severity` parameter unless you explicitly configure it, see [update in this message](https://github.com/aquasecurity/trivy-action/issues/309#issuecomment-2057669566) and the [official input docs](https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#inputs):
>limit-severities-for-sarif: By default SARIF format enforces output of all vulnerabilities regardless of configured severities. To override this behavior set this parameter to true