### PR TITLE
Kbauer/use semver tags

### DIFF
--- a/.github/workflows/ci-prerelease.yml
+++ b/.github/workflows/ci-prerelease.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           repo_base_url: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent"
-          package_name: ${{ env.NR_DISTRO }}
+          package_name: nr-otel-collector
           package_version: ${{ env.NR_VERSION }}
           platforms: "ubuntu2204,ubuntu2404"
 

--- a/.github/workflows/ci-prerelease_linux_on_demand.yml
+++ b/.github/workflows/ci-prerelease_linux_on_demand.yml
@@ -58,10 +58,6 @@ jobs:
           ref: ${{ env.BRANCH }}
           fetch-depth: 0
 
-      - name: "Tag this commit" # required for Goreleaser
-        # force tagging to allow to have a testing release with existing tag.
-        run: git tag -f nr-otel-collector-${{ env.TAG }}
-
       - name: Set and validate distribution name and version
         run: .github/workflows/scripts/set_version.sh
 
@@ -100,10 +96,10 @@ jobs:
         with:
           tag: ${{ env.TAG }}
           app_version: ${{ env.NR_VERSION }}
-          app_name: "${{ env.NR_DISTRO }}"
+          app_name: "nr-otel-collector"
           repo_name: "newrelic/opentelemetry-collector-releases"
           schema: "custom"
-          schema_url: "https://raw.githubusercontent.com/newrelic/opentelemetry-collector-releases/${{ env.SCHEMA_BRANCH }}/distributions/${{ env.NR_DISTRO }}/upload-schema-${{ matrix.os }}-${{ matrix.assetsType }}.yml"
+          schema_url: "https://raw.githubusercontent.com/newrelic/opentelemetry-collector-releases/${{ env.SCHEMA_BRANCH }}/distributions/nr-otel-collector/upload-schema-${{ matrix.os }}-${{ matrix.assetsType }}.yml"
           aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -50,4 +50,4 @@ jobs:
           password:  ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
 
       - name: Publish docker manifest
-        run: .github/workflows/scripts/docker_manifest_release.sh -i newrelic/${{ env.NR_DISTRO }} -v ${{ env.NR_VERSION }}
+        run: .github/workflows/scripts/docker_manifest_release.sh -i newrelic/nr-otel-collector -v ${{ env.NR_VERSION }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,6 @@ jobs:
           distribution: goreleaser
           version: '~> v1'
           args: --snapshot --clean --skip-sign --timeout 2h
-        env:
-          GORELEASER_CURRENT_TAG: 0.0.0
 
       - name: Extract image version
         run: echo "version=$(jq -r '.version' dist/metadata.json)" >> $GITHUB_ENV

--- a/.github/workflows/component_canaries.yml
+++ b/.github/workflows/component_canaries.yml
@@ -86,7 +86,7 @@ jobs:
         uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
-          container_make_target: "test/canaries PREVIOUS_IMAGE='newrelic/${{ env.PREVIOUS_NR_DISTRO }}:${{ env.PREVIOUS_NR_VERSION }}-rc' CURRENT_IMAGE='newrelic/${{ env.NR_DISTRO }}:${{ env.NR_VERSION }}-rc' ANSIBLE_INVENTORY='/srv/runner/inventory/${{ env.TAG }}-${{ env.PLATFORM }}-inventory.ec2' LIMIT=all"
+          container_make_target: "test/canaries PREVIOUS_IMAGE='newrelic/nr-otel-collector:${{ env.PREVIOUS_NR_VERSION }}-rc' CURRENT_IMAGE='newrelic/nr-otel-collector:${{ env.NR_VERSION }}-rc' ANSIBLE_INVENTORY='/srv/runner/inventory/${{ env.TAG }}-${{ env.PLATFORM }}-inventory.ec2' LIMIT=all"
           ecs_cluster_name: caos_otel_releases
           task_definition_name: otel-releases
           cloud_watch_logs_group_name: /ecs/test-prerelease-otel-releases

--- a/.github/workflows/component_publish.yml
+++ b/.github/workflows/component_publish.yml
@@ -104,10 +104,10 @@ jobs:
         with:
           tag: ${{ env.TAG }}
           app_version: ${{ env.NR_VERSION }}
-          app_name: "${{ env.NR_DISTRO }}"
+          app_name: "nr-otel-collector"
           repo_name: "newrelic/opentelemetry-collector-releases"
           schema: "custom"
-          schema_url: "https://raw.githubusercontent.com/newrelic/opentelemetry-collector-releases/${{ env.SCHEMA_BRANCH }}/distributions/${{ env.NR_DISTRO }}/upload-schema-${{ matrix.os }}-${{ matrix.assetsType }}.yml"
+          schema_url: "https://raw.githubusercontent.com/newrelic/opentelemetry-collector-releases/${{ env.SCHEMA_BRANCH }}/distributions/nr-otel-collector/upload-schema-${{ matrix.os }}-${{ matrix.assetsType }}.yml"
           aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}

--- a/.github/workflows/scripts/set_version.sh
+++ b/.github/workflows/scripts/set_version.sh
@@ -3,7 +3,7 @@
 set -e
 
 # fetch the history (including tags) from within a shallow clone like CI-GHA
-# supress error when the repository is a complete one.
+# suppress error when the repository is a complete one.
 git fetch --prune --unshallow 2> /dev/null || true
 
 tag=$(git describe --tags --abbrev=0)
@@ -12,64 +12,49 @@ prev_tag_commit=$(git rev-list --tags --skip=1 --max-count=1)
 prev_tag_git=$(git describe --tags --abbrev=0 "${prev_tag_commit}")
 prev_tag=${PREVIOUS_TAG:-${prev_tag_git}}
 
-# Expected tag format <distro>-<version> e.g. distro_name-major.minor.patch
-regex="^(.*)-([0-9]+\.[0-9]+\.[0-9]+)$"
+# Expected tag format following semantic versioning conventions, i.e major.minor.patch
+regex="^([0-9]+\.[0-9]+\.[0-9]+)$"
 
 if [[ "${tag}" =~ ${regex} ]]
 then
-    distro="${BASH_REMATCH[1]}"
-    version="${BASH_REMATCH[2]}"
+    version="${BASH_REMATCH[1]}"
 else
-    printf "Bad tag format: %s doesn't match expected pattern 'distro_name-major.minor.patch'\n" "${tag}" >&2
+    printf "Bad tag format: %s isn't following semantic versioning convention: 'major.minor.patch'\n" "${tag}" >&2
     exit 1
 fi
 
 if [[ "${prev_tag}" =~ ${regex} ]]
 then
-    prev_distro="${BASH_REMATCH[1]}"
-    prev_version="${BASH_REMATCH[2]}"
+    prev_version="${BASH_REMATCH[1]}"
 else
-    printf "Bad tag format: %s doesn't match expected pattern 'distro_name-major.minor.patch'\n" "${prev_tag}" >&2
+    printf "Bad tag format: %s isn't following semantic versioning convention: 'major.minor.patch'\n" "${prev_tag}" >&2
     exit 1
 fi
 
-printf "Distribution name: %s, Version name: %s\n" "${distro}" "${version}"
-printf "Previous distribution name: %s, Previous version name: %s\n" "${prev_distro}" "${prev_version}"
+printf "Version: %s\n" "${version}"
+printf "Previous version: %s\n" "${prev_version}"
 
 # Set the variables for later use in the GHA pipeline
 {
-    echo "NR_DISTRO=${distro}"
     echo "NR_VERSION=${version}"
     echo "NR_RELEASE_TAG=${tag}"
 
-    echo "PREVIOUS_NR_DISTRO=${prev_distro}"
     echo "PREVIOUS_NR_VERSION=${prev_version}"
     echo "PREVIOUS_NR_RELEASE_TAG=${prev_tag}"
 } >> "$GITHUB_ENV"
 
-# Assert manifest distro and version
-manifest_file="./distributions/${distro}/manifest.yaml"
+check_manifest_versions() {
+    expected_version="${version}"
+    MANIFESTS=$(find ./distributions -type f -name "manifest.yaml" | sort)
+    echo "Expect version ${expected_version} for all detected manifests:\n${MANIFESTS}"
 
-if [ ! -f "${manifest_file}" ]; then
-    printf "Manifest file for the distribution: '%s' extracted from the tag: '%s' wasn't found in %s\n" "${distro}" "${tag}" "${manifest_file}" >&2
-    exit 1
-fi
-
-# #TODO: Instead of asserting we could replace it in manifest file to avoid manual steps.
-manifest_version=$(yq .dist.version "${manifest_file}")
-
-if [ "${manifest_version}" != "${version}" ]; then
-    printf "Wrong manifest version: expected '%s' but was %s\n" "${version}" "${manifest_version}" >&2
-    exit 1
-fi
-
-manifest_distro=$(yq .dist.name "${manifest_file}")
-
-if [ "${manifest_distro}" != "${distro}" ]; then
-    printf "Wrong manifest version: expected '%s' but was %s\n" "${distro}" "${manifest_distro}" >&2
-    exit 1
-fi
-
-# Rename the tag locally to have a semantic versioning format
-# which is required by the packaging step.
-git tag "${version}" "${tag}"
+    for manifest_file in ${MANIFESTS}
+    do
+        version_in_manifest=$(awk '/[^_]+version:/{print $2}' ${manifest_file})
+        if [[ "${expected_version}" != "${version_in_manifest}" ]]; then
+            echo "Invalid version in manifest: Expected ${expected_version}, but got ${version_in_manifest} in '${manifest_file}'" >&2
+            exit 1
+        fi
+    done
+}
+check_manifest_versions

--- a/build.mk
+++ b/build.mk
@@ -57,12 +57,3 @@ goreleaser:
 			exit 1; \
 		fi \
 	}
-
-REMOTE?=git@github.com:newrelic/opentelemetry-collector-releases.git
-.PHONY: push-tags
-push-tags:
-	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
-	@echo "Adding tag ${TAG}"
-	@git tag -a ${TAG} -s -m "Version ${TAG}"
-	@echo "Pushing tag ${TAG}"
-	@git push ${REMOTE} ${TAG}


### PR DESCRIPTION
### Summary ([JIRA ticket](https://new-relic.atlassian.net/browse/NR-337872))
Moving to git tags following semantic conventions, i.e. without a distro prefix to get native support for goreleaser and similar release tools and avoid having to rely on bash scripts to bridge those gaps.
- CI previously encoded the 'distributions to release' in the prefix. Given that there is currently only one distro, we can hardcode this as input where necessary. When adding a new distro, we will publish all artifacts on the same version and increment the version based on the most impactful change to any distro (instead of maintaining a version per prefixed-version per distro). This is also what the [open-telemetry repo does](https://github.com/open-telemetry/opentelemetry-collector-releases/pull/740/files).
- Main changes are to `.github/workflows/scripts/set_version.sh` which no longer has to deal with the distro prefix (hardcoded wherever code relied upon the output of this script). Some modifications were necessary to still enforce version consistency across distros but most of the logic was borrowed from [this script checking names in the manifest](https://github.com/newrelic/opentelemetry-collector-releases/pull/157/files#diff-37cb51dfc7e46c0e73db4723c3e0ea7c9fcef08dee88080738327123ebc44af9L42-L58)

### Misc
- Removed unused `push-tags` target (copy of [releases repo](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/Makefile#L67-L74)) from `build.mk` to avoid confusion as it also relates to tagging.

### Preparation
Before this will pass CI, we'll have to merge two dummy commits with tags adhering to semantic versioning, e.g. `0.8.6` and `0.8.7`.
- Without prep, the build was failing as expected with error indicating most recent tag not adhering to semver.
- [PR for 0.8.6](https://github.com/newrelic/opentelemetry-collector-releases/pull/159)
- [PR for 0.8.7](https://github.com/newrelic/opentelemetry-collector-releases/pull/160)
- tagged both commits with annotated tags and pushed to github
```
git tag -a '0.8.6' -m 'release 0.8.6' afb1b521bbe2868336b0d384f82b4e35897f7af9
git tag -a '0.8.7' -m 'release 0.8.7' a6cc0f2a39a248e5855f9130b903517f975de8b4
git push origin 0.8.6
git push origin 0.8.7
```
- rebased this PR, [retriggering CI](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/12125630101/job/33805999133?pr=158) with two most recent tags being semver-compliant -> CI passes