### PR TITLE
chore: dummy 0.8.6 release to move to semver tags

### DIFF
--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -2,7 +2,7 @@ dist:
   module: github.com/newrelic/opentelemetry-collector-releases/nr-otel-collector
   name: nr-otel-collector
   description: New Relic OpenTelemetry Collector
-  version: 0.8.5
+  version: 0.8.6
   output_path: ./_build
   otelcol_version: 0.108.0
 


### PR DESCRIPTION
Dummy release for #158  to have a dedicated dummy commit in `main` that can be tagged with tag name adhering to semver.