### PR TITLE
chore: remove unused gnostic replace directive

### DIFF
--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -50,8 +50,6 @@ providers:
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:
-  # See https://github.com/google/gnostic/issues/262
-  - github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0.5.5
   ### Transitive deps determined via `go mod graph | grep $dep@$dep_replace_version`
   # Why: Fixes CVE-2024-41110
   # Transitive dep of: prometheusreceiver


### PR DESCRIPTION
### Summary
- Directive seems to be no longer necessary. Based on the [linked issue](https://github.com/google/gnostic/issues/262), if it was still necessary, `go get -u` would fail but it didn't when executing it locally and also the dependency is no longer mentioned in the `go.mod`, so I assume it just is no longer a transitive dependency.

### TODO
- [x] merge #165 first and rebase