### PR TITLE
ci: fix missing build step in nightly CI

### DIFF
--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: 🔄 CI | Nightly
 
 on:
   workflow_dispatch:
@@ -29,6 +29,9 @@ jobs:
         with:
           go-version: '~1.22.3'
           check-latest: true
+
+      - name: Verify build
+        run: make ci
 
       - uses: docker/setup-qemu-action@v2
 


### PR DESCRIPTION
### Summary
- Build step was missing from nightly build [causing goreleaser to fail](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/12362541149/job/34502061604) as it expects source files to be present
- Renamed action as it was still using the normal CI name