### PR TITLE
Kbauer/fix nightly build 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # required for tag metadata
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || 'main' }}
+          fetch-depth: 0 # required for tag metadata
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -38,7 +38,8 @@ ci_test-fast: ci_load-image ci_build-load-mocked-otlp-image
 	cd ${THIS_MAKEFILE_DIR} && \
 	E2E_TEST__K8S_CONTEXT_NAME=${K8S_CONTEXT_NAME} \
 	E2E_TEST__IMAGE_TAG=${IMAGE_TAG} \
-	go test ./... -count=1 -short
+	E2E_TEST__TEST_MODE=fastOnly \
+	go test ./... -count=1
 
 .PHONY: ci_test-slow
 ci_test-slow: ci_load-image ci_build-load-mocked-otlp-image
@@ -50,6 +51,7 @@ ci_test-slow: ci_load-image ci_build-load-mocked-otlp-image
 	E2E_TEST__NR_API_KEY=${NR_API_KEY} \
 	E2E_TEST__NR_ACCOUNT_ID=${NR_ACCOUNT_ID} \
 	E2E_TEST__NR_API_BASE_URL=${NR_API_BASE_URL} \
+	E2E_TEST__TEST_MODE=slowOnly \
 	go test ./... -count=1
 
 ################

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -34,15 +34,15 @@ ci_build-load-mocked-otlp-image: assert_cluster-exists
 	kind load docker-image mocked_otlp:latest --name ${KIND_CLUSTER_NAME}
 
 .PHONY: ci_test-fast
+ci_test-fast: TEST_MODE=fastOnly
 ci_test-fast: ci_load-image ci_build-load-mocked-otlp-image
-	cd ${THIS_MAKEFILE_DIR} && \
-	E2E_TEST__K8S_CONTEXT_NAME=${K8S_CONTEXT_NAME} \
-	E2E_TEST__IMAGE_TAG=${IMAGE_TAG} \
-	E2E_TEST__TEST_MODE=fastOnly \
-	go test ./... -count=1
 
 .PHONY: ci_test-slow
-ci_test-slow: ci_load-image ci_build-load-mocked-otlp-image
+ci_test-slow: TEST_MODE=slowOnly
+ci_test-slow: ci_load-image ci_build-load-mocked-otlp-image ci_test
+
+.PHONY: ci_test
+ci_test:
 	cd ${THIS_MAKEFILE_DIR} && \
 	E2E_TEST__K8S_CONTEXT_NAME=${K8S_CONTEXT_NAME} \
 	E2E_TEST__IMAGE_TAG=${IMAGE_TAG} \
@@ -51,7 +51,7 @@ ci_test-slow: ci_load-image ci_build-load-mocked-otlp-image
 	E2E_TEST__NR_API_KEY=${NR_API_KEY} \
 	E2E_TEST__NR_ACCOUNT_ID=${NR_ACCOUNT_ID} \
 	E2E_TEST__NR_API_BASE_URL=${NR_API_BASE_URL} \
-	E2E_TEST__TEST_MODE=slowOnly \
+	E2E_TEST__TEST_MODE=${TEST_MODE} \
 	go test ./... -count=1
 
 ################
@@ -66,14 +66,18 @@ local_create-cluster-if-not-exists:
 local_build-image:
 	cd $(ROOT_DIR) && goreleaser --snapshot --clean --skip-sign
 
-.PHONY: local_test-fast
+.PHONY: local_test
 # hardcode an image you build with local_build-image, then run this target to run tests against it
 local_test: IMAGE_TAG=insert_locally_available_tag_to_test_here
-local_test: local_create-cluster-if-not-exists ci_test-fast
+local_test: local_create-cluster-if-not-exists ci_test
+
+.PHONY: local_test-fast
+local_test-fast: TEST_MODE=fastOnly
+local_test-fast: local_test
 
 .PHONY: local_test-slow
-local_test-slow: IMAGE_TAG=insert_locally_available_tag_to_test_here
-local_test-slow: local_create-cluster-if-not-exists ci_test-slow
+local_test-slow: TEST_MODE=slowOnly
+local_test-slow: local_test
 
 .PHONY: local_helm-cleanup
 local_helm-cleanup:

--- a/test/e2e/hostmetrics/hostmetrics_test.go
+++ b/test/e2e/hostmetrics/hostmetrics_test.go
@@ -12,6 +12,7 @@ import (
 	"test/e2e/util/chart"
 	helmutil "test/e2e/util/helm"
 	k8sutil "test/e2e/util/k8s"
+	testutil "test/e2e/util/test"
 	"testing"
 	"time"
 )
@@ -51,6 +52,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestStartupBehavior(t *testing.T) {
+	testutil.TagAsFastTest(t)
 	cleanup := helmutil.ApplyChart(t, kubectlOptions, testChart.AsChart(), "hostmetrics-startup")
 	defer cleanup()
 

--- a/test/e2e/util/env/env.go
+++ b/test/e2e/util/env/env.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	TestMode       = "E2E_TEST__TEST_MODE"
 	K8sContextName = "E2E_TEST__K8S_CONTEXT_NAME"
 	ImageTag       = "E2E_TEST__IMAGE_TAG"
 	NrBackendUrl   = "E2E_TEST__NR_BACKEND_URL"
@@ -22,6 +23,10 @@ func getEnvVar(envVar string) string {
 		panic(fmt.Sprintf("%s not set", envVar))
 	}
 	return value
+}
+
+func GetTestMode() string {
+	return os.Getenv(TestMode)
 }
 
 func GetK8sContextName() string {

--- a/test/e2e/util/test/test.go
+++ b/test/e2e/util/test/test.go
@@ -1,9 +1,28 @@
 package test
 
-import "testing"
+import (
+	"strings"
+	envutil "test/e2e/util/env"
+	"testing"
+)
+
+const (
+	slowOnly = "slowOnly"
+	fastOnly = "fastOnly"
+)
 
 func TagAsSlowTest(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping slow test in short mode: ", t.Name())
+	if isModeEnabled(fastOnly) {
+		t.Skip("Skipping slow test: ", t.Name())
 	}
+}
+
+func TagAsFastTest(t *testing.T) {
+	if isModeEnabled(slowOnly) {
+		t.Skip("Skipping fast test: ", t.Name())
+	}
+}
+
+func isModeEnabled(mode string) bool {
+	return strings.Contains(envutil.GetTestMode(), mode)
 }


### PR DESCRIPTION
### Summary
- Add `fetch-depth` to ensure tags are checked out as nightly otherwise creates a snapshot with version [0.0.0](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/12395675029/job/34601944664#step:7:29) while the normal ci uses the [correct tag](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/12362786938/job/34502821653#step:8:28)
- Only execute slow tests during nightly as fast tests already ran on merge but maintain the ability for local development to execute 'only slow tests', 'only fast tests' or all tests
   - migrated test filter mechanism to use an a string based env var to allow the above-mentioned three modes and it's also not hard to imagine that we might come up with a third test type which would be easily integrated into this pattern