### PR TITLE
ci: skip terraform workflow for dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
           TRIVY_SKIP_JAVA_DB_UPDATE: true
   terraform:
     uses: ./.github/workflows/component_terraform.yml
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     with:
       branch: ${{ github.ref }}
       tf_work_subdir: permanent


### PR DESCRIPTION
### Summary
- [Dependabot PR](https://github.com/newrelic/opentelemetry-collector-releases/pull/167) failed [due to missing secrets](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/12362465283/job/34501827930?pr=167) for the new terraform workflow. This is expected as dependabot PRs don't and shouldn't have access to secrets as a malicious dependency upgrade could leak those in certain language ecosystems (more details [here](https://github.com/dependabot/dependabot-core/issues/3253)). There are ways to remedy this by introducing a more complex dependabot workflow but until we actually have need for this complexity, it seems more appropriate to just skip the terraform plan of our CI.
If dependabot creates a PR for terraform resources, we can locally do a plan instead where we could take a moment to vet the dependency upgrade more closely beforehand.
- Condition expression was adapted [based on what I found in the docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#common-dependabot-automations)