### PR TITLE
feat: Adding provisioning of permanent EKS test cluster

### DIFF
--- a/test/terraform/modules/eks_cluster/main.tf
+++ b/test/terraform/modules/eks_cluster/main.tf
@@ -1,0 +1,39 @@
+locals {
+  iam_role_permissions_boundary = "arn:aws:iam::${var.account_id}:policy/resource-provisioner-boundary"
+}
+
+module "eks_cluster" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.31.4"
+
+  cluster_name    = var.name
+  cluster_version = "1.31"
+
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access  = true
+
+  vpc_id     = var.vpc_id
+  subnet_ids = var.subnet_ids
+
+  enable_cluster_creator_admin_permissions = true
+  iam_role_permissions_boundary            = local.iam_role_permissions_boundary
+
+  eks_managed_node_group_defaults = {
+    iam_role_permissions_boundary = local.iam_role_permissions_boundary
+
+    instance_types = ["m5.large"]
+
+    min_size     = 2
+    max_size     = 2
+    desired_size = 2
+  }
+
+  eks_managed_node_groups = {
+    default = {
+      # Starting on 1.30, AL2023 is the default AMI type for EKS managed node groups
+      ami_type = "AL2023_x86_64_STANDARD"
+    }
+  }
+}
+
+

--- a/test/terraform/modules/eks_cluster/main.tf
+++ b/test/terraform/modules/eks_cluster/main.tf
@@ -1,6 +1,53 @@
 locals {
   iam_role_permissions_boundary = "arn:aws:iam::${var.account_id}:policy/resource-provisioner-boundary"
+
+  # We need to ensure we don't attempt to use any of the disallowed zones:
+  # https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html
+  valid_availability_zones = [
+    for zone in data.aws_availability_zones.available.names : zone
+    if !contains(data.aws_availability_zones.disallowed.names, zone)
+  ]
 }
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+data "aws_availability_zones" "disallowed" {
+  filter {
+    name = "zone-id"
+    values = ["use1-az3", "usw1-az2", "cac1-az3"]
+  }
+}
+
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.17.0"
+
+  name = "${var.name}-vpc"
+
+  cidr = "10.0.0.0/16"
+
+  azs = slice(local.valid_availability_zones, 0, 2)
+
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+
+  enable_nat_gateway = true
+  # Will be assigned to the first public subnet, in this case 10.0.4.0/24.  Private subnets will
+  # route their internet traffic through it.
+  # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#single-nat-gateway
+  single_nat_gateway = true
+
+  vpc_flow_log_permissions_boundary = local.iam_role_permissions_boundary
+}
+
 
 module "eks_cluster" {
   source  = "terraform-aws-modules/eks/aws"
@@ -12,8 +59,8 @@ module "eks_cluster" {
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
 
-  vpc_id     = var.vpc_id
-  subnet_ids = var.subnet_ids
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
 
   enable_cluster_creator_admin_permissions = true
   iam_role_permissions_boundary            = local.iam_role_permissions_boundary

--- a/test/terraform/modules/eks_cluster/outputs.tf
+++ b/test/terraform/modules/eks_cluster/outputs.tf
@@ -1,0 +1,11 @@
+output "cluster_name" {
+  value = module.eks_cluster.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks_cluster.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  value = module.eks_cluster.cluster_certificate_authority_data
+}

--- a/test/terraform/modules/eks_cluster/vars.tf
+++ b/test/terraform/modules/eks_cluster/vars.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  description = "name of the cluster"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC id"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "subnet ids"
+  type = list(string)
+}
+
+variable "account_id" {
+  description = "account id"
+  type        = string
+}

--- a/test/terraform/modules/eks_cluster/vars.tf
+++ b/test/terraform/modules/eks_cluster/vars.tf
@@ -3,16 +3,6 @@ variable "name" {
   type        = string
 }
 
-variable "vpc_id" {
-  description = "VPC id"
-  type        = string
-}
-
-variable "subnet_ids" {
-  description = "subnet ids"
-  type = list(string)
-}
-
 variable "account_id" {
   description = "account id"
   type        = string

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -1,13 +1,25 @@
-# read default vpc and create security group to validate basic setup and role permissions
-data "aws_vpc" "example_read_resource" {
+data "aws_vpc" "this" {
   id = "vpc-015d2f927c8b5dea7"
 }
 
-resource "aws_security_group" "example_write_resource" {
-  name   = "example_write_resource_from_terraform"
-  vpc_id = data.aws_vpc.example_read_resource.id
-
-  tags = {
-    created_by = "terraform"
+data "aws_subnets" "this" {
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.this.id]
   }
+
+  filter {
+    name = "availability-zone"
+    values = ["us-east-1a", "us-east-1b"]
+  }
+}
+
+module "ci_e2e_cluster" {
+  source = "../modules/eks_cluster"
+
+  name       = "aws-ci-e2etest"
+  account_id = var.aws_account_id
+
+  vpc_id     = data.aws_vpc.this.id
+  subnet_ids = data.aws_subnets.this.ids
 }

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -2,24 +2,10 @@ data "aws_vpc" "this" {
   id = "vpc-015d2f927c8b5dea7"
 }
 
-data "aws_subnets" "this" {
-  filter {
-    name = "vpc-id"
-    values = [data.aws_vpc.this.id]
-  }
-
-  filter {
-    name = "availability-zone"
-    values = ["us-east-1a", "us-east-1b"]
-  }
-}
 
 module "ci_e2e_cluster" {
   source = "../modules/eks_cluster"
 
   name       = "aws-ci-e2etest"
   account_id = var.aws_account_id
-
-  vpc_id     = data.aws_vpc.this.id
-  subnet_ids = data.aws_subnets.this.ids
 }

--- a/test/terraform/permanent/providers.tf
+++ b/test/terraform/permanent/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "1.9.8"
   required_providers {
     aws = {
-      version = "5.76.0"
+      version = "5.81.0"
     }
   }
 }


### PR DESCRIPTION
Adds a permanent test cluster for deploying nightly builds.   Out of the gates we'll just use a single linux node group and eventually build out what we need longer term.  I'll have a followup pr shortly to add a simple helm release.


Should be able to pull an auth token for the cluster via:
```
data "aws_eks_cluster_auth" "this" {
  name = module.ci_e2e_cluster.cluster_name
}