### PR TITLE
feat: Deploy permanent backend into test cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,3 +88,5 @@ jobs:
       aws_access_key_id: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{secrets.OTELCOMM_AWS_TEST_ACC_SECRET_ACCESS_KEY}}
       aws_account_id: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}
+      nr_backend_url: ${{secrets.NR_STAGING_BACKEND_URL}}
+      nr_ingest_key: ${{ secrets.OTELCOMM_NR_INGEST_KEY }}

--- a/.github/workflows/component_terraform.yml
+++ b/.github/workflows/component_terraform.yml
@@ -58,6 +58,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
       TF_VAR_aws_account_id: ${{ secrets.aws_account_id }}
+      TF_VAR_nr_backend_url: ${{ secrets.nr_backend_url }}
+      TF_VAR_nr_ingest_key: ${{ secrets.nr_ingest_key }}
 
     steps:
       - name: Checkout repository

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -9,3 +9,30 @@ module "ci_e2e_cluster" {
   name       = "aws-ci-e2etest"
   account_id = var.aws_account_id
 }
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.ci_e2e_cluster.cluster_name
+}
+
+resource "helm_release" "ci_e2e_nightly" {
+  depends_on = [module.ci_e2e_cluster]
+
+  name      = "ci-e2etest-nightly"
+  namespace = "ci-e2etest-nightly"
+  chart     = "../../charts/nr_backend"
+
+  set {
+    name  = "image.pullPolicy"
+    value = "Always"
+  }
+
+  set {
+    name  = "secrets.nrBackendUrl"
+    value = var.nr_backend_url
+  }
+
+  set {
+    name  = "secrets.nrIngestKey"
+    value = var.nr_ingest_key
+  }
+}

--- a/test/terraform/permanent/providers.tf
+++ b/test/terraform/permanent/providers.tf
@@ -4,6 +4,9 @@ terraform {
     aws = {
       version = "5.81.0"
     }
+    helm = {
+      version = "2.17.0"
+    }
   }
 }
 
@@ -24,5 +27,13 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::${var.aws_account_id}:role/resource-provisioner"
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host  = module.ci_e2e_cluster.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.ci_e2e_cluster.cluster_certificate_authority_data)
+    token = data.aws_eks_cluster_auth.this.token
   }
 }

--- a/test/terraform/permanent/vars.tf
+++ b/test/terraform/permanent/vars.tf
@@ -6,5 +6,17 @@ variable "aws_account_id" {
 variable "aws_region" {
   type        = string
   description = "AWS region to deploy to"
-  default = "us-east-1"
+  default     = "us-east-1"
+}
+
+variable "nr_backend_url" {
+  type        = string
+  description = "NR endpoint used in test cluster"
+  sensitive   = true
+}
+
+variable "nr_ingest_key" {
+  type        = string
+  description = "NR ingest key used in test cluster"
+  sensitive   = true
 }


### PR DESCRIPTION
Deploys our test helm-chart into the permanent eks cluster.  Currently it will just pull the most latest image until we add a test repository and/or publish nightly builds.