### PR TITLE
fix: Ensure helm creates the nightly namespace

### DIFF
--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -18,8 +18,10 @@ resource "helm_release" "ci_e2e_nightly" {
   depends_on = [module.ci_e2e_cluster]
 
   name      = "ci-e2etest-nightly"
-  namespace = "ci-e2etest-nightly"
   chart     = "../../charts/nr_backend"
+
+  create_namespace = true
+  namespace = "nightly"
 
   set {
     name  = "image.pullPolicy"


### PR DESCRIPTION
Need to add the flag to ensure the namespace is created.  Additionally i updated it to just `nightly` for now since the use cse of the cluster can be inferred from the cluster name.