### PR TITLE
feat: Provision ECR for test builds

### DIFF
--- a/test/terraform/modules/eks_cluster/outputs.tf
+++ b/test/terraform/modules/eks_cluster/outputs.tf
@@ -9,3 +9,7 @@ output "cluster_endpoint" {
 output "cluster_certificate_authority_data" {
   value = module.eks_cluster.cluster_certificate_authority_data
 }
+
+output "cluster_iam_role_arn" {
+  value = module.eks_cluster.cluster_iam_role_arn
+}


### PR DESCRIPTION
Provisions a private ECR repo and assigns read-access to the test cluster arn using the aws tf [module](https://registry.terraform.io/modules/terraform-aws-modules/ecr/aws/latest).  A followup pr will add publishing of the nightly build.

