### PR TITLE
Kbauer/add tf based bare metal test

### DIFF
--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -55,7 +55,7 @@ jobs:
           cluster_name: ${{ env.TEST_CLUSTER_NAME }}
           wait: 60s
 
-      - name: Run local e2e tests
+      - name: Run slow local tests
         run: |
           IMAGE_TAG=${{ env.version }}-rc-amd64 \
           KIND_CLUSTER_NAME=${{ env.TEST_CLUSTER_NAME }} \
@@ -65,3 +65,10 @@ jobs:
           NR_ACCOUNT_ID=${{ secrets.OTELCOMM_NR_TEST_ACCOUNT_ID }} \
           NR_API_BASE_URL=${{ secrets.NR_STAGING_API_BASE_URL }} \
           make -f ./test/e2e/Makefile ci_test-slow
+
+      - name: Run nightly tests
+        run: |
+          NR_API_KEY=${{ secrets.OTELCOMM_NR_API_KEY }} \
+          NR_ACCOUNT_ID=${{ secrets.OTELCOMM_NR_TEST_ACCOUNT_ID }} \
+          NR_API_BASE_URL=${{ secrets.NR_STAGING_API_BASE_URL }} \
+          make -f ./test/e2e/Makefile ci_test-nightly

--- a/test/charts/nr_backend/templates/daemonset.yaml
+++ b/test/charts/nr_backend/templates/daemonset.yaml
@@ -29,6 +29,10 @@ spec:
             - name: health
               containerPort: 13133
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -42,7 +46,7 @@ spec:
                   name: daemonset-secrets
                   key: nrIngestKey
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "host.name={{ .Values.collector.hostname }}"
+              value: "host.name={{ .Values.collector.hostname }}-$(NODE_NAME)"
 ---
 apiVersion: v1
 kind: Secret

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -41,6 +41,10 @@ ci_test-fast: ci_test
 ci_test-slow: TEST_MODE=slowOnly
 ci_test-slow: ci_test
 
+.PHONY: ci_test-nightly
+ci_test-nightly: TEST_MODE=nightlyOnly
+ci_test-nightly: ci_test
+
 .PHONY: ci_test
 ci_test: ci_load-image ci_build-load-mocked-otlp-image
 	cd ${THIS_MAKEFILE_DIR} && \

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -35,18 +35,18 @@ ci_build-load-mocked-otlp-image: assert_cluster-exists
 
 .PHONY: ci_test-fast
 ci_test-fast: TEST_MODE=fastOnly
-ci_test-fast: ci_test
+ci_test-fast: ci_load-image ci_build-load-mocked-otlp-image ci_test
 
 .PHONY: ci_test-slow
 ci_test-slow: TEST_MODE=slowOnly
-ci_test-slow: ci_test
+ci_test-slow: ci_load-image ci_test
 
 .PHONY: ci_test-nightly
 ci_test-nightly: TEST_MODE=nightlyOnly
 ci_test-nightly: ci_test
 
 .PHONY: ci_test
-ci_test: ci_load-image ci_build-load-mocked-otlp-image
+ci_test:
 	cd ${THIS_MAKEFILE_DIR} && \
 	E2E_TEST__K8S_CONTEXT_NAME=${K8S_CONTEXT_NAME} \
 	E2E_TEST__IMAGE_TAG=${IMAGE_TAG} \

--- a/test/e2e/hostmetrics/hostmetrics_test.go
+++ b/test/e2e/hostmetrics/hostmetrics_test.go
@@ -46,15 +46,11 @@ func setupTest(tb testing.TB) testEnv {
 	}}
 }
 
-func TestMain(m *testing.M) {
-	testId = testutil.NewTestId()
-	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
-	testChart = chart.MockedBackend
-	m.Run()
-}
-
 func TestStartupBehavior(t *testing.T) {
 	testutil.TagAsFastTest(t)
+	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
+	testChart = chart.MockedBackend
+	testId = testutil.NewTestId()
 	cleanup := helmutil.ApplyChart(t, kubectlOptions, testChart.AsChart(), "hostmetrics-startup", testId)
 	defer cleanup()
 

--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -10,24 +10,35 @@ import (
 	"time"
 )
 
-var ec2HostNamePattern = testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04")
-var k8sNodeHostNamePattern = testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node")
+type systemUnderTest struct {
+	hostNamePattern string
+	excludedMetrics []string
+}
 
-func TestNightlyBuildCollectors(t *testing.T) {
+var ec2 = systemUnderTest{
+	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04"),
+}
+var k8sNode = systemUnderTest{
+	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node"),
+	excludedMetrics: []string{"system.paging.usage"},
+}
+
+func TestNightlyHostMetrics(t *testing.T) {
 	testutil.TagAsNightlyTest(t)
 
+	// space out requests to not run into 25 concurrent request limit
 	requestsPerSecond := 4.0
 	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
-	for _, hostNamePattern := range []string{ec2HostNamePattern, k8sNodeHostNamePattern} {
+	client := nr.NewClient()
 
-		for i, testCase := range spec.GetOnHostTestCases() {
-			t.Run(fmt.Sprintf(testCase.Name), func(t *testing.T) {
+	for _, sut := range []systemUnderTest{ec2, k8sNode} {
+		for i, testCase := range spec.GetOnHostTestCasesWithout(sut.excludedMetrics) {
+			t.Run(fmt.Sprintf("%s/%d/%s", sut.hostNamePattern, i, testCase.Name), func(t *testing.T) {
 				t.Parallel()
 				assertionFactory := assert.NewNrMetricAssertionFactory(
-					fmt.Sprintf("WHERE host.name like '%s'", hostNamePattern),
-					"5 minutes ago",
+					fmt.Sprintf("WHERE host.name like '%s'", sut.hostNamePattern),
+					"24 hour ago",
 				)
-				client := nr.NewClient()
 				assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
 				// space out requests to avoid rate limiting
 				time.Sleep(time.Duration(i) * requestSpacing)

--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -1,0 +1,38 @@
+package hostmetrics
+
+import (
+	"fmt"
+	"test/e2e/util/assert"
+	"test/e2e/util/nr"
+	"test/e2e/util/spec"
+	testutil "test/e2e/util/test"
+	"testing"
+	"time"
+)
+
+var ec2HostNamePattern = testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04")
+var k8sNodeHostNamePattern = testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node")
+
+func TestNightlyBuildCollectors(t *testing.T) {
+	testutil.TagAsNightlyTest(t)
+
+	requestsPerSecond := 4.0
+	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
+	for _, hostNamePattern := range []string{ec2HostNamePattern, k8sNodeHostNamePattern} {
+
+		for i, testCase := range spec.GetOnHostTestCases() {
+			t.Run(fmt.Sprintf(testCase.Name), func(t *testing.T) {
+				t.Parallel()
+				assertionFactory := assert.NewNrMetricAssertionFactory(
+					fmt.Sprintf("WHERE host.name like '%s'", hostNamePattern),
+					"5 minutes ago",
+				)
+				client := nr.NewClient()
+				assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
+				// space out requests to avoid rate limiting
+				time.Sleep(time.Duration(i) * requestSpacing)
+				assertion.Execute(t, client)
+			})
+		}
+	}
+}

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -54,10 +54,10 @@ func TestStartupBehavior(t *testing.T) {
 	})
 	// wait for at least one default metric harvest cycle (60s) and some buffer to allow NR ingest to process data
 	time.Sleep(70 * time.Second)
-	// TODO: build some kind of semaphore based client wrapper?
 	// space out requests to not run into 25 concurrent request limit
 	requestsPerSecond := 4.0
 	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
+	client := nr.NewClient()
 
 	for i, testCase := range spec.GetOnHostTestCases() {
 		t.Run(fmt.Sprintf(testCase.Name), func(t *testing.T) {
@@ -66,7 +66,6 @@ func TestStartupBehavior(t *testing.T) {
 				fmt.Sprintf("WHERE host.name like '%s'", testChart.NrQueryHostNamePattern),
 				"5 minutes ago",
 			)
-			client := nr.NewClient()
 			assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
 			// space out requests to avoid rate limiting
 			time.Sleep(time.Duration(i) * requestSpacing)

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"test/e2e/util/assert"
 	"test/e2e/util/chart"
-	envutil "test/e2e/util/env"
 	helmutil "test/e2e/util/helm"
 	k8sutil "test/e2e/util/k8s"
 	"test/e2e/util/nr"
@@ -22,10 +21,8 @@ const (
 )
 
 var (
-	kubectlOptions            *k8s.KubectlOptions
-	testChart                 chart.NrBackendChart
-	testId                    string
-	collectorReportedHostname string
+	kubectlOptions *k8s.KubectlOptions
+	testChart      chart.NrBackendChart
 )
 
 type testEnv struct {
@@ -42,42 +39,31 @@ func setupTest(tb testing.TB) testEnv {
 
 }
 
-func TestMain(m *testing.M) {
-	testId = testutil.NewTestId()
-	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
-	environmentName := "local"
-	if envutil.IsContinuousIntegration() {
-		environmentName = "ci"
-	}
-	collectorReportedHostname = fmt.Sprintf("nr-otel-collector-%s-%s", environmentName, testId)
-	testChart = chart.NewNrBackendChart(collectorReportedHostname)
-	m.Run()
-}
-
 func TestStartupBehavior(t *testing.T) {
 	testutil.TagAsSlowTest(t)
 	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
 	testId := testutil.NewTestId()
 	testChart = chart.NewNrBackendChart(testId)
 
-	t.Logf("host.name used for test: %s", testChart.CollectorHostname)
+	t.Logf("hostname used for test: %s", testChart.NrQueryHostNamePattern)
 	cleanup := helmutil.ApplyChart(t, kubectlOptions, testChart.AsChart(), "hostmetrics-startup", testId)
 	t.Cleanup(cleanup)
 	te := setupTest(t)
 	t.Cleanup(func() {
 		te.teardown(t)
 	})
+	// wait for at least one default metric harvest cycle (60s) and some buffer to allow NR ingest to process data
+	time.Sleep(70 * time.Second)
+	// TODO: build some kind of semaphore based client wrapper?
 	// space out requests to not run into 25 concurrent request limit
 	requestsPerSecond := 4.0
 	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
-	// wait for at least one default metric harvest cycle (60s) and some buffer to allow NR ingest to process data
-	time.Sleep(70 * time.Second)
 
 	for i, testCase := range spec.GetOnHostTestCases() {
-		t.Run(fmt.Sprintf("%s-%s", testCase.Metric.Name, testCase.Metric.WhereClause), func(t *testing.T) {
+		t.Run(fmt.Sprintf(testCase.Name), func(t *testing.T) {
 			t.Parallel()
 			assertionFactory := assert.NewNrMetricAssertionFactory(
-				fmt.Sprintf("WHERE host.name = '%s'", testChart.CollectorHostname),
+				fmt.Sprintf("WHERE host.name like '%s'", testChart.NrQueryHostNamePattern),
 				"5 minutes ago",
 			)
 			client := nr.NewClient()

--- a/test/e2e/util/chart/nr_backend.go
+++ b/test/e2e/util/chart/nr_backend.go
@@ -1,14 +1,23 @@
 package chart
 
-import envutil "test/e2e/util/env"
+import (
+	"fmt"
+	envutil "test/e2e/util/env"
+)
 
 type NrBackendChart struct {
-	collectorHostname string
+	CollectorHostname string
 }
 
-func NewNrBackendChart(collectorHostname string) NrBackendChart {
+func NewNrBackendChart(testId string) NrBackendChart {
+	environmentName := "local"
+	if envutil.IsContinuousIntegration() {
+		environmentName = "ci"
+	}
+	collectorHostname := fmt.Sprintf("nr-otel-collector-%s-%s", environmentName, testId)
+
 	return NrBackendChart{
-		collectorHostname: collectorHostname,
+		CollectorHostname: collectorHostname,
 	}
 }
 
@@ -28,6 +37,6 @@ func (m *NrBackendChart) RequiredChartValues() map[string]string {
 		"image.tag":            envutil.GetImageTag(),
 		"secrets.nrBackendUrl": envutil.GetNrBackendUrl(),
 		"secrets.nrIngestKey":  envutil.GetNrIngestKey(),
-		"collector.hostname":   m.collectorHostname,
+		"collector.hostname":   m.CollectorHostname,
 	}
 }

--- a/test/e2e/util/spec/on_host.go
+++ b/test/e2e/util/spec/on_host.go
@@ -96,7 +96,7 @@ var testCases = []TestCase{
 			Name: "system.cpu.load_average.15m",
 		},
 		Assertions: []assert.NrAssertion{
-			{AggregationFunction: "max", ComparisonOperator: ">", Threshold: 0},
+			{AggregationFunction: "max", ComparisonOperator: ">=", Threshold: 0},
 		}},
 	{
 		Name: "host receiver memory.usage cached",
@@ -302,4 +302,20 @@ var testCases = []TestCase{
 
 func GetOnHostTestCases() []TestCase {
 	return testCases
+}
+
+func GetOnHostTestCasesWithout(excludedMetric []string) []TestCase {
+	var filteredTestCases []TestCase
+	for _, testCase := range testCases {
+		included := true
+		for _, skippedMetric := range excludedMetric {
+			if testCase.Metric.Name == skippedMetric {
+				included = false
+			}
+		}
+		if included {
+			filteredTestCases = append(filteredTestCases, testCase)
+		}
+	}
+	return filteredTestCases
 }

--- a/test/e2e/util/test/hostname.go
+++ b/test/e2e/util/test/hostname.go
@@ -1,0 +1,15 @@
+package test
+
+import "fmt"
+
+func NewHostNamePrefix(envName string, deployId string, hostType string) string {
+	// only a prefix as helm chart appends hostId
+	return fmt.Sprintf("%s-%s-%s", envName, deployId, hostType)
+}
+
+const Wildcard = "%"
+
+func NewNrQueryHostNamePattern(envName string, deployId string, hostType string) string {
+	hostId := Wildcard
+	return fmt.Sprintf("%s-%s-%s-%s", envName, deployId, hostType, hostId)
+}

--- a/test/e2e/util/test/test.go
+++ b/test/e2e/util/test/test.go
@@ -8,24 +8,46 @@ import (
 )
 
 const (
-	slowOnly = "slowOnly"
-	fastOnly = "fastOnly"
+	fastOnly    = "fastOnly"
+	slowOnly    = "slowOnly"
+	nightlyOnly = "nightlyOnly"
 )
 
-func TagAsSlowTest(t *testing.T) {
-	if isModeEnabled(fastOnly) {
-		t.Skip("Skipping slow test: ", t.Name())
-	}
-}
+var onlyModes = []string{fastOnly, slowOnly, nightlyOnly}
 
 func TagAsFastTest(t *testing.T) {
-	if isModeEnabled(slowOnly) {
+	if isAnyModeOf(allOnlyModesExcept(fastOnly)) {
 		t.Skip("Skipping fast test: ", t.Name())
 	}
 }
 
-func isModeEnabled(mode string) bool {
-	return strings.Contains(envutil.GetTestMode(), mode)
+func TagAsSlowTest(t *testing.T) {
+	if isAnyModeOf(allOnlyModesExcept(slowOnly)) {
+		t.Skip("Skipping slow test: ", t.Name())
+	}
+}
+
+func TagAsNightlyTest(t *testing.T) {
+	if isAnyModeOf(allOnlyModesExcept(nightlyOnly)) {
+		t.Skip("Skipping nightly test: ", t.Name())
+	}
+}
+
+func isAnyModeOf(modes []string) bool {
+	result := false
+	for _, mode := range modes {
+		result = result || strings.Contains(envutil.GetTestMode(), mode)
+	}
+	return result
+}
+func allOnlyModesExcept(filterOut string) []string {
+	var result []string
+	for _, onlyMode := range onlyModes {
+		if onlyMode != filterOut {
+			result = append(result, onlyMode)
+		}
+	}
+	return result
 }
 
 func NewTestId() string {

--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -1,0 +1,66 @@
+locals {
+  collector_reported_hostname = "${var.test_environment}-${var.deploy_id}-ec2_ubuntu24_04-0"
+}
+
+data "aws_ami" "ubuntu24_04" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+data "aws_vpc" "ec2_vpc" {
+  id = var.vpc_id
+}
+
+data "aws_subnets" "private_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
+  filter {
+    name   = "tag:Name"
+    values = ["*private*"]
+  }
+}
+
+resource "aws_security_group" "ec2_allow_all_egress" {
+  name        = "nightly-ec2-all-egress"
+  description = "Allow all outbound traffic"
+  vpc_id      = data.aws_vpc.ec2_vpc.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "ubuntu24_04" {
+  ami                    = data.aws_ami.ubuntu24_04.id
+  instance_type          = "t2.micro"
+  subnet_id              = data.aws_subnets.private_subnets.ids[0]
+  vpc_security_group_ids = [aws_security_group.ec2_allow_all_egress.id]
+
+  user_data = <<-EOF
+              #!/bin/bash
+              export DEBIAN_FRONTEND=noninteractive
+              curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | gpg --dearmor -o /usr/share/keyrings/newrelic-infra.gpg
+              printf '%s\n' 'deb [signed-by=/usr/share/keyrings/newrelic-infra.gpg] http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt noble main' | tee /etc/apt/sources.list.d/newrelic-infra.list
+              apt-get update
+              apt-get install nr-otel-collector=${var.collector_version}
+              echo 'NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}' >> /etc/nr-otel-collector/nr-otel-collector.conf
+              echo "OTEL_RESOURCE_ATTRIBUTES='host.name=${local.collector_reported_hostname}'" >> /etc/nr-otel-collector/nr-otel-collector.conf
+              systemctl reload-or-restart nr-otel-collector.service
+              EOF
+}

--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -1,5 +1,6 @@
 locals {
   collector_reported_hostname = "${var.test_environment}-${var.deploy_id}-ec2_ubuntu24_04-0"
+  collector_version_specifier = "${var.collector_version == "" ? "" : "="}${var.collector_version}"
 }
 
 data "aws_ami" "ubuntu24_04" {
@@ -54,11 +55,18 @@ resource "aws_instance" "ubuntu24_04" {
 
   user_data = <<-EOF
               #!/bin/bash
+              echo 'Configuring swap file to ensure system.paging.usage metric gets published'
+              dd if=/dev/zero of=/swapfile bs=1M count=128
+              chmod 600 /swapfile
+              mkswap /swapfile
+              swapon /swapfile
+              swapon -s
+              echo 'Installing Collector'
               export DEBIAN_FRONTEND=noninteractive
               curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | gpg --dearmor -o /usr/share/keyrings/newrelic-infra.gpg
               printf '%s\n' 'deb [signed-by=/usr/share/keyrings/newrelic-infra.gpg] http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt noble main' | tee /etc/apt/sources.list.d/newrelic-infra.list
               apt-get update
-              apt-get install nr-otel-collector=${var.collector_version}
+              apt-get install nr-otel-collector${local.collector_version_specifier}
               echo 'NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}' >> /etc/nr-otel-collector/nr-otel-collector.conf
               echo "OTEL_RESOURCE_ATTRIBUTES='host.name=${local.collector_reported_hostname}'" >> /etc/nr-otel-collector/nr-otel-collector.conf
               systemctl reload-or-restart nr-otel-collector.service

--- a/test/terraform/modules/ec2/vars.tf
+++ b/test/terraform/modules/ec2/vars.tf
@@ -23,4 +23,5 @@ variable "nr_ingest_key" {
 variable "collector_version" {
   description = "Version of nr-otel-collector to install"
   type        = string
+  default     = ""
 }

--- a/test/terraform/modules/ec2/vars.tf
+++ b/test/terraform/modules/ec2/vars.tf
@@ -1,0 +1,26 @@
+variable "test_environment" {
+  type        = string
+  description = "Name of test environment to distinguish entities"
+  default     = "nightly"
+}
+
+variable "deploy_id" {
+    type        = string
+    description = "An id to uniquely identify a deployment to an environment, e.g. for change tracking"
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC where the instance will be deployed to (in one of the private subnets)"
+  type        = string
+}
+
+variable "nr_ingest_key" {
+  description = "New Relic ingest license key"
+  type        = string
+  sensitive   = true
+}
+
+variable "collector_version" {
+  description = "Version of nr-otel-collector to install"
+  type        = string
+}

--- a/test/terraform/modules/eks_cluster/outputs.tf
+++ b/test/terraform/modules/eks_cluster/outputs.tf
@@ -13,3 +13,7 @@ output "cluster_certificate_authority_data" {
 output "cluster_iam_role_arn" {
   value = module.eks_cluster.cluster_iam_role_arn
 }
+
+output "eks_vpc_id" {
+  value = module.vpc.vpc_id
+}

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -44,7 +44,7 @@ resource "helm_release" "ci_e2e_nightly" {
   }
 
   set {
-    name = "collector.hostname"
+    name  = "collector.hostname"
     value = "${var.test_environment}-${random_string.deploy_id.result}-k8s_node"
   }
 }
@@ -85,11 +85,9 @@ module "ecr" {
 
 
 module "ci_e2e_ec2" {
-  source = "../modules/ec2"
-  nr_ingest_key  =  var.nr_ingest_key
+  source        = "../modules/ec2"
+  nr_ingest_key = var.nr_ingest_key
   # reuse vpc to avoid having to pay for second NAT gateway for this simple use case
-  vpc_id = module.ci_e2e_cluster.eks_vpc_id
+  vpc_id    = module.ci_e2e_cluster.eks_vpc_id
   deploy_id = random_string.deploy_id.result
-  # TODO: use nightly instead
-  collector_version = "0.8.5"
 }

--- a/test/terraform/permanent/providers.tf
+++ b/test/terraform/permanent/providers.tf
@@ -28,13 +28,6 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${var.aws_account_id}:role/resource-provisioner"
   }
-  #   default_tags {
-  #     tags = {
-  #       "Terraform"    = "true"
-  #       "Repo"         = "newrelic-opentelemetry-collector-releases"
-  #       "TerraformDir" = "permanent"
-  #     }
-  #   }
 }
 
 provider "helm" {

--- a/test/terraform/permanent/providers.tf
+++ b/test/terraform/permanent/providers.tf
@@ -21,19 +21,26 @@ terraform {
 }
 
 provider "aws" {
-  region = var.aws_region
+  region              = var.aws_region
   allowed_account_ids = [var.aws_account_id]
   # expect AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as env vars
 
   assume_role {
     role_arn = "arn:aws:iam::${var.aws_account_id}:role/resource-provisioner"
   }
+  #   default_tags {
+  #     tags = {
+  #       "Terraform"    = "true"
+  #       "Repo"         = "newrelic-opentelemetry-collector-releases"
+  #       "TerraformDir" = "permanent"
+  #     }
+  #   }
 }
 
 provider "helm" {
   kubernetes {
-    host  = module.ci_e2e_cluster.cluster_endpoint
+    host                   = module.ci_e2e_cluster.cluster_endpoint
     cluster_ca_certificate = base64decode(module.ci_e2e_cluster.cluster_certificate_authority_data)
-    token = data.aws_eks_cluster_auth.this.token
+    token                  = data.aws_eks_cluster_auth.this.token
   }
 }


### PR DESCRIPTION
### Summary
- Add EC2 instance running ubuntu 24.04 to nightly test infra. Using latest collector until we have a nightly version
- Add NRQL-based tests that assert that nightly test infra produces expected hostmetrics
  - `system.paging.usage`: requires a swapfile to be allocated, [added](https://repost.aws/knowledge-center/ec2-memory-swap-file) it for EC2 but skip this test for k8s as the overhead of creating an AMI for k8s nodes to use seems to much to support this test case.
  - `system.cpu.load_average.15m`: [drops to 0](https://onenr.io/0LwGl9qm8R6) in idle for the EC2, so after running long enough this test would fail, thus I changed it to `>=0`. Alternative would be to add a load-generating script.

#### TODO
- [ ] add EC2 for ubuntu22 to test on two different os versions

### Misc
#### Hostname changes
- Previous PR added `OTEL_RESOURCE_ATTRIBUTES` specifier to force predictable hostnames to be reported to NR. Added some structure to those names to enforce consistency across different test environments (local-dev1, local-dev2, ci, nightly) and host machines (k8s-node1, k8s-node2, ec2-ubuntu,...) 
  - Appended the node name to k8s nodes as the daemonset deploys the collector to multiple/different nodes, so using the same hostname doesn't make sense and also causes issues in the UI because two entities with the same hostname got created

#### Removal of TestMain
- No longer use `TestMain` for test setup as test tagging/filtering should be the first logic to run to avoid errors due to missing env vars that are not necessary for the subsets of tests run, e.g. NR_INGEST_KEY not required for nightly tests. `testing.M` doesn't provide an API to skip a test, so it can't be used in the `testutil` package.

### Test
- Nightly tests specified in this PR don't pass yet because a) ec2 is not deployed yet and b) the eks node collector still uses the old host name. To ensure the tests do work, I temporarily deployed the EC2 for a few hours and ran the tests using the old k8s hostname using the following patch:
[nightly-test.patch](https://github.com/user-attachments/files/18351771/nightly-test.patch)
