### PR TITLE
Publish nightly build to ECR

### DIFF
--- a/.github/workflows/ci-prerelease.yml
+++ b/.github/workflows/ci-prerelease.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.3'
+          go-version: '1.23'
           check-latest: true
 
       - name: Generate distribution sources

--- a/.github/workflows/ci-prerelease.yml
+++ b/.github/workflows/ci-prerelease.yml
@@ -40,10 +40,10 @@ jobs:
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
 
       - name: Build binaries & packages with GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v1'
+          version: '~> v2'
           args: release --rm-dist --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-prerelease_linux_on_demand.yml
+++ b/.github/workflows/ci-prerelease_linux_on_demand.yml
@@ -80,10 +80,10 @@ jobs:
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
 
       - name: Build binaries & packages with GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v1'
+          version: '~> v2'
           args: release --rm-dist --skip-docker --skip-publish --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-prerelease_linux_on_demand.yml
+++ b/.github/workflows/ci-prerelease_linux_on_demand.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.3'
+          go-version: '1.23'
           check-latest: true
 
       - name: Generate distribution sources

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,10 @@ jobs:
       - uses: docker/setup-buildx-action@v2
 
       - name: Build binaries & packages with GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v1'
+          version: '~> v2'
           args: --snapshot --clean --skip-sign --timeout 2h
 
       - name: Extract image version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.3'
+          go-version: '1.23'
           check-latest: true
 
       - name: Verify build
@@ -44,7 +44,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: --snapshot --clean --skip-sign --timeout 2h
+          args: --snapshot --clean --skip=sign --timeout 2h
 
       - name: Extract image version
         run: echo "version=$(jq -r '.version' dist/metadata.json)" >> $GITHUB_ENV

--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -39,11 +39,11 @@ jobs:
       - uses: docker/setup-buildx-action@v2
 
       - name: Build binaries & packages with GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: '~> v1'
-          args: --snapshot --clean --skip-sign --timeout 2h
+          version: '~> v2'
+          args: --snapshot --clean --skip=sign --timeout 2h
 
       - name: Extract image version
         run: echo "version=$(jq -r '.version' dist/metadata.json)" >> $GITHUB_ENV

--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22.3'
+          go-version: '1.23'
           check-latest: true
 
       - name: Verify build
@@ -65,3 +65,24 @@ jobs:
           NR_ACCOUNT_ID=${{ secrets.OTELCOMM_NR_TEST_ACCOUNT_ID }} \
           NR_API_BASE_URL=${{ secrets.NR_STAGING_API_BASE_URL }} \
           make -f ./test/e2e/Makefile ci_test-slow
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.OTELCOMM_AWS_TEST_ACC_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}:role/resource-provisioner
+          role-skip-session-tagging: true
+
+      - name: Login to ECR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/nr-otel-collector
+
+      - name: Build and publish nightly binaries & packages with GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: --clean --timeout 2h --config .goreleaser-nightly.yaml

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
-project_name: opentelemetry-collector-releases
+project_name: opentelemetry-collector-releases-nightly
 builds:
   - id: nr-otel-collector
     goos:
@@ -74,7 +74,7 @@ dockers:
     goarch: amd64
     dockerfile: distributions/nr-otel-collector/Dockerfile
     image_templates:
-      - newrelic/nr-otel-collector:{{ .Version }}-rc-amd64
+      - newrelic/nr-otel-collector:{{ .Version }}-nightly-amd64
     extra_files:
       - configs/nr-otel-collector-agent-linux.yaml
     build_flag_templates:
@@ -83,14 +83,14 @@ dockers:
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}
       - --label=org.opencontainers.image.revision={{.FullCommit}}
-      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.version={{.Version}}-nightly
       - --label=org.opencontainers.image.source={{.GitURL}}
     use: buildx
   - goos: linux
     goarch: arm64
     dockerfile: distributions/nr-otel-collector/Dockerfile
     image_templates:
-      - newrelic/nr-otel-collector:{{ .Version }}-rc-arm64
+      - newrelic/nr-otel-collector:{{ .Version }}-nightly-arm64
     extra_files:
       - configs/nr-otel-collector-agent-linux.yaml
     build_flag_templates:
@@ -99,55 +99,15 @@ dockers:
       - --label=org.opencontainers.image.created={{.Date}}
       - --label=org.opencontainers.image.name={{.ProjectName}}
       - --label=org.opencontainers.image.revision={{.FullCommit}}
-      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.version={{.Version}}-nightly
       - --label=org.opencontainers.image.source={{.GitURL}}
     use: buildx
+
 docker_manifests:
-  - name_template: newrelic/nr-otel-collector:{{ .Version }}-rc
+  - name_template: newrelic/nr-otel-collector:{{ .Version }}-nightly
     image_templates:
-      - newrelic/nr-otel-collector:{{ .Version }}-rc-amd64
-      - newrelic/nr-otel-collector:{{ .Version }}-rc-arm64
-
-signs:
-  -
-    id: checksums
-
-    # Path to the checksum command.
-    cmd: ./scripts/generate_checksum.sh
-    args: [
-      "-f", "{{ .Env.artifact }}",
-    ]
-    artifacts: all
-  -
-    id: signing
-
-    # Path to the signature command.
-    cmd: ./scripts/signing/sign.sh
-    args: [
-      "-f", "{{ .Env.artifact }}",
-      "-m", "{{ .Env.GPG_MAIL }}",
-      "-p", "{{ .Env.GPG_PASSPHRASE }}",
-      "-k", "{{ .Env.GPG_PRIVATE_KEY_BASE64 }}"
-    ]
-    artifacts: all
-
-publishers:
-  - name: GH Publisher
-    cmd: ./scripts/gh_publisher.sh -t {{ .Env.NR_RELEASE_TAG }} -f {{ abs .ArtifactPath }}
-    extra_files:
-      - glob: "./dist/*.asc"
-      - glob: "./dist/*.sum"
-    env:
-      - GITHUB_TOKEN={{ .Env.GITHUB_TOKEN }}
-
-git:
-  # What should be used to sort tags when gathering the current and previous
-  # tags if there are more than one tag in the same commit.
-  #
-  # This is required because of the SemVer tag renaming.
-  #
-  # Default: `-version:refname`
-  tag_sort: -version:creatordate
+      - newrelic/nr-otel-collector:{{ .Version }}-nightly-amd64
+      - newrelic/nr-otel-collector:{{ .Version }}-nightly-arm64
 
 # Skip creating/updating gh release.
 release:
@@ -160,3 +120,6 @@ checksum:
 # Skip auto-generating changelog.
 changelog:
   disable: true
+
+snapshot:
+  name_template: "nightly-next"

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -21,6 +21,7 @@ builds:
       - -trimpath
     env:
       - CGO_ENABLED=0
+
 archives:
   - id: nr-otel-collector
     builds:
@@ -122,4 +123,4 @@ changelog:
   disable: true
 
 snapshot:
-  name_template: "nightly-next"
+  version_template: "{{ incpatch .Version }}-SNAPSHOT-{{.ShortCommit}}-nightly"

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/opentelemetry-collector-releases/internal/tools
 
-go 1.20
+go 1.23
 
 require go.elastic.co/go-licence-detector v0.6.0
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,13 +50,11 @@ container_path_ocb_config="${container_work_dir}/${ocb_config}"
 
 echo "Building: $distribution"
 docker run \
-  --name ocb \
   -v "$(pwd)/${ocb_config}:${container_path_ocb_config}" \
+  -v "$(pwd)/${output_dir}:${container_work_dir}/${output_dir}:rw" \
   "${builder_image}" \
   --config "${container_path_ocb_config}" \
   --skip-compilation=${skipcompilation}
-
-docker cp "ocb:${container_work_dir}/${output_dir}/." "${output_dir}"
 
 if [[ "$ensure_docker_write_permissions" == "true" ]]; then
     # change owner of output dir back to the 'build' user to allow access for following steps

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,11 +50,13 @@ container_path_ocb_config="${container_work_dir}/${ocb_config}"
 
 echo "Building: $distribution"
 docker run \
+  --name ocb \
   -v "$(pwd)/${ocb_config}:${container_path_ocb_config}" \
-  -v "$(pwd)/${output_dir}:${container_work_dir}/${output_dir}:rw" \
   "${builder_image}" \
   --config "${container_path_ocb_config}" \
   --skip-compilation=${skipcompilation}
+
+docker cp "ocb:${container_work_dir}/${output_dir}/." "${output_dir}"
 
 if [[ "$ensure_docker_write_permissions" == "true" ]]; then
     # change owner of output dir back to the 'build' user to allow access for following steps

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -64,7 +64,7 @@ local_create-cluster-if-not-exists:
 
 .PHONY: local_build-image
 local_build-image:
-	cd $(ROOT_DIR) && goreleaser --snapshot --clean --skip-sign
+	cd $(ROOT_DIR) && goreleaser --snapshot --clean --skip=sign
 
 .PHONY: local_test
 # hardcode an image you build with local_build-image, then run this target to run tests against it


### PR DESCRIPTION
- Updates golang to `1.23` to be consistent with the otel distros
- Updates goreleaser to v2 with minor changes to cli arguments
- Adds a new goreleaser config file for nightly builds (this is a temporary step until we we get a pro license setup)
- Additional steps to the nightly ci workflow to publish to ECR.  We'll need a followup pr to publish additional artifacts to s3 for the bare metals tests as well.