### PR TITLE
Add missing ECR registry url

### DIFF
--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -83,8 +83,6 @@ jobs:
 
       - name: Build and publish nightly binaries & packages with GoReleaser
         uses: goreleaser/goreleaser-action@v6
-        env:
-          REGISTRY: ${{ env.REGISTRY }}
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -85,4 +85,4 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: --clean --timeout 2h --config .goreleaser-nightly.yaml
+          args: --skip=validate --clean --timeout 2h --config .goreleaser-nightly.yaml

--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -13,6 +13,7 @@ on:
 
 env:
   TEST_CLUSTER_NAME: ci-e2etest-nightly
+  REGISTRY: ${{ secrets.OTELCOMM_AWS_TEST_ACC_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/nr-otel-collector
 
 jobs:
   slow-tests:
@@ -82,7 +83,9 @@ jobs:
 
       - name: Build and publish nightly binaries & packages with GoReleaser
         uses: goreleaser/goreleaser-action@v6
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: --skip=validate --clean --timeout 2h --config .goreleaser-nightly.yaml
+          args: --clean --timeout 2h --config .goreleaser-nightly.yaml

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -76,6 +76,7 @@ dockers:
     dockerfile: distributions/nr-otel-collector/Dockerfile
     image_templates:
       - '{{ .Env.REGISTRY }}:{{ .Version }}-nightly-amd64'
+      - '{{ .Env.REGISTRY }}:nightly-amd64'
     extra_files:
       - configs/nr-otel-collector-agent-linux.yaml
     build_flag_templates:
@@ -92,6 +93,7 @@ dockers:
     dockerfile: distributions/nr-otel-collector/Dockerfile
     image_templates:
       - '{{ .Env.REGISTRY }}:{{ .Version }}-nightly-arm64'
+      - '{{ .Env.REGISTRY }}:nightly-arm64'
     extra_files:
       - configs/nr-otel-collector-agent-linux.yaml
     build_flag_templates:
@@ -109,6 +111,10 @@ docker_manifests:
     image_templates:
       - '{{ .Env.REGISTRY }}:{{ .Version }}-nightly-amd64'
       - '{{ .Env.REGISTRY }}:{{ .Version }}-nightly-arm64'
+  - name_template: '{{ .Env.REGISTRY }}:nightly'
+    image_templates:
+      - '{{ .Env.REGISTRY }}:nightly-amd64'
+      - '{{ .Env.REGISTRY }}:nightly-arm64'
 
 # Skip creating/updating gh release.
 release:

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -75,7 +75,7 @@ dockers:
     goarch: amd64
     dockerfile: distributions/nr-otel-collector/Dockerfile
     image_templates:
-      - newrelic/nr-otel-collector:{{ .Version }}-nightly-amd64
+      - '{{ .Env.REGISTRY }}:{{ .Version }}-nightly-amd64'
     extra_files:
       - configs/nr-otel-collector-agent-linux.yaml
     build_flag_templates:
@@ -91,7 +91,7 @@ dockers:
     goarch: arm64
     dockerfile: distributions/nr-otel-collector/Dockerfile
     image_templates:
-      - newrelic/nr-otel-collector:{{ .Version }}-nightly-arm64
+      - '{{ .Env.REGISTRY }}:{{ .Version }}-nightly-arm64'
     extra_files:
       - configs/nr-otel-collector-agent-linux.yaml
     build_flag_templates:
@@ -105,10 +105,10 @@ dockers:
     use: buildx
 
 docker_manifests:
-  - name_template: newrelic/nr-otel-collector:{{ .Version }}-nightly
+  - name_template: '{{ .Env.REGISTRY }}:{{ .Version }}-nightly'
     image_templates:
-      - newrelic/nr-otel-collector:{{ .Version }}-nightly-amd64
-      - newrelic/nr-otel-collector:{{ .Version }}-nightly-arm64
+      - '{{ .Env.REGISTRY }}:{{ .Version }}-nightly-amd64'
+      - '{{ .Env.REGISTRY }}:{{ .Version }}-nightly-arm64'
 
 # Skip creating/updating gh release.
 release:

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -64,6 +64,8 @@ module "ecr" {
 
   repository_name = "nr-otel-collector"
 
+  repository_image_tag_mutability = "MUTABLE"
+
   repository_read_write_access_arns = [data.aws_iam_session_context.current.issuer_arn]
   repository_read_access_arns = [module.ci_e2e_cluster.cluster_iam_role_arn]
 


### PR DESCRIPTION
- We weren't passing in the ECR repo value to goreleaser, that is now solved via envvar
- Updating ECR to allow mutability until we get the publishing all ironed out
- Adding a simple `nightly` tag