### PR TITLE
chore: Update nightly goreleaser config to include blobs

### DIFF
--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -130,3 +130,9 @@ changelog:
 
 snapshot:
   version_template: "{{ incpatch .Version }}-SNAPSHOT-{{.ShortCommit}}-nightly"
+
+blobs:
+  - provider: s3
+    region: us-east-1
+    bucket: nr-releases
+    directory: 'opentelemetry-collector-releases/{{ .Tag }}'

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -50,7 +50,7 @@ module "ecr" {
 module "s3_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
 
-  bucket = "nr-otel-collector"
+  bucket = "nr-releases"
   acl    = "private"
 
   control_object_ownership = true


### PR DESCRIPTION
- Renames the build artifact s3 bucket to something more generic: `nr-releases`
- Updates blob path to: `nr-releases/opentelemetry-collector-releases/{{ .Tag }}`
- Published binaries on nightly build