### PR TITLE
chore: Create ECR repos on a per distro basis

### DIFF
--- a/test/terraform/permanent/outputs.tf
+++ b/test/terraform/permanent/outputs.tf
@@ -1,3 +1,3 @@
-output "ecr_repository_url" {
-  value = module.ecr.repository_url
+output "ecr_repository_urls" {
+  value = [for key, value in module.ecr : value.repository_url]
 }


### PR DESCRIPTION
As we create new distros we'll want separate ECRs, this should create a repo for each subfolder of `./distributions`