### PR TITLE
Kbauer/add tf based bare metal test

### DIFF
--- a/.github/workflows/ci_nightly.yaml
+++ b/.github/workflows/ci_nightly.yaml
@@ -56,7 +56,7 @@ jobs:
           cluster_name: ${{ env.TEST_CLUSTER_NAME }}
           wait: 60s
 
-      - name: Run local e2e tests
+      - name: Run slow local tests
         run: |
           IMAGE_TAG=${{ env.version }}-rc-amd64 \
           KIND_CLUSTER_NAME=${{ env.TEST_CLUSTER_NAME }} \
@@ -87,3 +87,10 @@ jobs:
           distribution: goreleaser
           version: '~> v2'
           args: --skip=announce,validate --clean --timeout 2h --config .goreleaser-nightly.yaml
+
+      - name: Run nightly tests
+        run: |
+          NR_API_KEY=${{ secrets.OTELCOMM_NR_API_KEY }} \
+          NR_ACCOUNT_ID=${{ secrets.OTELCOMM_NR_TEST_ACCOUNT_ID }} \
+          NR_API_BASE_URL=${{ secrets.NR_STAGING_API_BASE_URL }} \
+          make -f ./test/e2e/Makefile ci_test-nightly

--- a/test/charts/nr_backend/templates/daemonset.yaml
+++ b/test/charts/nr_backend/templates/daemonset.yaml
@@ -29,6 +29,10 @@ spec:
             - name: health
               containerPort: 13133
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -42,7 +46,7 @@ spec:
                   name: daemonset-secrets
                   key: nrIngestKey
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "host.name={{ .Values.collector.hostname }}"
+              value: "host.name={{ .Values.collector.hostname }}-$(NODE_NAME)"
 ---
 apiVersion: v1
 kind: Secret

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -41,6 +41,10 @@ ci_test-fast: ci_test
 ci_test-slow: TEST_MODE=slowOnly
 ci_test-slow: ci_test
 
+.PHONY: ci_test-nightly
+ci_test-nightly: TEST_MODE=nightlyOnly
+ci_test-nightly: ci_test
+
 .PHONY: ci_test
 ci_test: ci_load-image ci_build-load-mocked-otlp-image
 	cd ${THIS_MAKEFILE_DIR} && \

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -35,18 +35,18 @@ ci_build-load-mocked-otlp-image: assert_cluster-exists
 
 .PHONY: ci_test-fast
 ci_test-fast: TEST_MODE=fastOnly
-ci_test-fast: ci_test
+ci_test-fast: ci_load-image ci_build-load-mocked-otlp-image ci_test
 
 .PHONY: ci_test-slow
 ci_test-slow: TEST_MODE=slowOnly
-ci_test-slow: ci_test
+ci_test-slow: ci_load-image ci_test
 
 .PHONY: ci_test-nightly
 ci_test-nightly: TEST_MODE=nightlyOnly
 ci_test-nightly: ci_test
 
 .PHONY: ci_test
-ci_test: ci_load-image ci_build-load-mocked-otlp-image
+ci_test:
 	cd ${THIS_MAKEFILE_DIR} && \
 	E2E_TEST__K8S_CONTEXT_NAME=${K8S_CONTEXT_NAME} \
 	E2E_TEST__IMAGE_TAG=${IMAGE_TAG} \

--- a/test/e2e/hostmetrics/hostmetrics_test.go
+++ b/test/e2e/hostmetrics/hostmetrics_test.go
@@ -46,15 +46,11 @@ func setupTest(tb testing.TB) testEnv {
 	}}
 }
 
-func TestMain(m *testing.M) {
-	testId = testutil.NewTestId()
-	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
-	testChart = chart.MockedBackend
-	m.Run()
-}
-
 func TestStartupBehavior(t *testing.T) {
 	testutil.TagAsFastTest(t)
+	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
+	testChart = chart.MockedBackend
+	testId = testutil.NewTestId()
 	cleanup := helmutil.ApplyChart(t, kubectlOptions, testChart.AsChart(), "hostmetrics-startup", testId)
 	defer cleanup()
 

--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -10,24 +10,35 @@ import (
 	"time"
 )
 
-var ec2HostNamePattern = testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04")
-var k8sNodeHostNamePattern = testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node")
+type systemUnderTest struct {
+	hostNamePattern string
+	excludedMetrics []string
+}
 
-func TestNightlyBuildCollectors(t *testing.T) {
+var ec2 = systemUnderTest{
+	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04"),
+}
+var k8sNode = systemUnderTest{
+	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node"),
+	excludedMetrics: []string{"system.paging.usage"},
+}
+
+func TestNightlyHostMetrics(t *testing.T) {
 	testutil.TagAsNightlyTest(t)
 
+	// space out requests to not run into 25 concurrent request limit
 	requestsPerSecond := 4.0
 	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
-	for _, hostNamePattern := range []string{ec2HostNamePattern, k8sNodeHostNamePattern} {
+	client := nr.NewClient()
 
-		for i, testCase := range spec.GetOnHostTestCases() {
-			t.Run(fmt.Sprintf(testCase.Name), func(t *testing.T) {
+	for _, sut := range []systemUnderTest{ec2, k8sNode} {
+		for i, testCase := range spec.GetOnHostTestCasesWithout(sut.excludedMetrics) {
+			t.Run(fmt.Sprintf("%s/%d/%s", sut.hostNamePattern, i, testCase.Name), func(t *testing.T) {
 				t.Parallel()
 				assertionFactory := assert.NewNrMetricAssertionFactory(
-					fmt.Sprintf("WHERE host.name like '%s'", hostNamePattern),
-					"5 minutes ago",
+					fmt.Sprintf("WHERE host.name like '%s'", sut.hostNamePattern),
+					"24 hour ago",
 				)
-				client := nr.NewClient()
 				assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
 				// space out requests to avoid rate limiting
 				time.Sleep(time.Duration(i) * requestSpacing)

--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -15,7 +15,10 @@ type systemUnderTest struct {
 	excludedMetrics []string
 }
 
-var ec2 = systemUnderTest{
+var ec2Ubuntu22 = systemUnderTest{
+	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu22_04"),
+}
+var ec2Ubuntu24 = systemUnderTest{
 	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04"),
 }
 var k8sNode = systemUnderTest{
@@ -31,13 +34,13 @@ func TestNightlyHostMetrics(t *testing.T) {
 	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
 	client := nr.NewClient()
 
-	for _, sut := range []systemUnderTest{ec2, k8sNode} {
+	for _, sut := range []systemUnderTest{ec2Ubuntu22, ec2Ubuntu24, k8sNode} {
 		for i, testCase := range spec.GetOnHostTestCasesWithout(sut.excludedMetrics) {
 			t.Run(fmt.Sprintf("%s/%d/%s", sut.hostNamePattern, i, testCase.Name), func(t *testing.T) {
 				t.Parallel()
 				assertionFactory := assert.NewNrMetricAssertionFactory(
 					fmt.Sprintf("WHERE host.name like '%s'", sut.hostNamePattern),
-					"24 hour ago",
+					"2 hour ago",
 				)
 				assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
 				// space out requests to avoid rate limiting

--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -1,0 +1,38 @@
+package hostmetrics
+
+import (
+	"fmt"
+	"test/e2e/util/assert"
+	"test/e2e/util/nr"
+	"test/e2e/util/spec"
+	testutil "test/e2e/util/test"
+	"testing"
+	"time"
+)
+
+var ec2HostNamePattern = testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04")
+var k8sNodeHostNamePattern = testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node")
+
+func TestNightlyBuildCollectors(t *testing.T) {
+	testutil.TagAsNightlyTest(t)
+
+	requestsPerSecond := 4.0
+	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
+	for _, hostNamePattern := range []string{ec2HostNamePattern, k8sNodeHostNamePattern} {
+
+		for i, testCase := range spec.GetOnHostTestCases() {
+			t.Run(fmt.Sprintf(testCase.Name), func(t *testing.T) {
+				t.Parallel()
+				assertionFactory := assert.NewNrMetricAssertionFactory(
+					fmt.Sprintf("WHERE host.name like '%s'", hostNamePattern),
+					"5 minutes ago",
+				)
+				client := nr.NewClient()
+				assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
+				// space out requests to avoid rate limiting
+				time.Sleep(time.Duration(i) * requestSpacing)
+				assertion.Execute(t, client)
+			})
+		}
+	}
+}

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -54,10 +54,10 @@ func TestStartupBehavior(t *testing.T) {
 	})
 	// wait for at least one default metric harvest cycle (60s) and some buffer to allow NR ingest to process data
 	time.Sleep(70 * time.Second)
-	// TODO: build some kind of semaphore based client wrapper?
 	// space out requests to not run into 25 concurrent request limit
 	requestsPerSecond := 4.0
 	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
+	client := nr.NewClient()
 
 	for i, testCase := range spec.GetOnHostTestCases() {
 		t.Run(fmt.Sprintf(testCase.Name), func(t *testing.T) {
@@ -66,7 +66,6 @@ func TestStartupBehavior(t *testing.T) {
 				fmt.Sprintf("WHERE host.name like '%s'", testChart.NrQueryHostNamePattern),
 				"5 minutes ago",
 			)
-			client := nr.NewClient()
 			assertion := assertionFactory.NewNrMetricAssertion(testCase.Metric, testCase.Assertions)
 			// space out requests to avoid rate limiting
 			time.Sleep(time.Duration(i) * requestSpacing)

--- a/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
+++ b/test/e2e/hostmetrics_slow/hostmetrics_slow_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"test/e2e/util/assert"
 	"test/e2e/util/chart"
-	envutil "test/e2e/util/env"
 	helmutil "test/e2e/util/helm"
 	k8sutil "test/e2e/util/k8s"
 	"test/e2e/util/nr"
@@ -22,10 +21,8 @@ const (
 )
 
 var (
-	kubectlOptions            *k8s.KubectlOptions
-	testChart                 chart.NrBackendChart
-	testId                    string
-	collectorReportedHostname string
+	kubectlOptions *k8s.KubectlOptions
+	testChart      chart.NrBackendChart
 )
 
 type testEnv struct {
@@ -42,42 +39,31 @@ func setupTest(tb testing.TB) testEnv {
 
 }
 
-func TestMain(m *testing.M) {
-	testId = testutil.NewTestId()
-	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
-	environmentName := "local"
-	if envutil.IsContinuousIntegration() {
-		environmentName = "ci"
-	}
-	collectorReportedHostname = fmt.Sprintf("nr-otel-collector-%s-%s", environmentName, testId)
-	testChart = chart.NewNrBackendChart(collectorReportedHostname)
-	m.Run()
-}
-
 func TestStartupBehavior(t *testing.T) {
 	testutil.TagAsSlowTest(t)
 	kubectlOptions = k8sutil.NewKubectlOptions(TestNamespace)
 	testId := testutil.NewTestId()
 	testChart = chart.NewNrBackendChart(testId)
 
-	t.Logf("host.name used for test: %s", testChart.CollectorHostname)
+	t.Logf("hostname used for test: %s", testChart.NrQueryHostNamePattern)
 	cleanup := helmutil.ApplyChart(t, kubectlOptions, testChart.AsChart(), "hostmetrics-startup", testId)
 	t.Cleanup(cleanup)
 	te := setupTest(t)
 	t.Cleanup(func() {
 		te.teardown(t)
 	})
+	// wait for at least one default metric harvest cycle (60s) and some buffer to allow NR ingest to process data
+	time.Sleep(70 * time.Second)
+	// TODO: build some kind of semaphore based client wrapper?
 	// space out requests to not run into 25 concurrent request limit
 	requestsPerSecond := 4.0
 	requestSpacing := time.Duration((1/requestsPerSecond)*1000) * time.Millisecond
-	// wait for at least one default metric harvest cycle (60s) and some buffer to allow NR ingest to process data
-	time.Sleep(70 * time.Second)
 
 	for i, testCase := range spec.GetOnHostTestCases() {
-		t.Run(fmt.Sprintf("%s-%s", testCase.Metric.Name, testCase.Metric.WhereClause), func(t *testing.T) {
+		t.Run(fmt.Sprintf(testCase.Name), func(t *testing.T) {
 			t.Parallel()
 			assertionFactory := assert.NewNrMetricAssertionFactory(
-				fmt.Sprintf("WHERE host.name = '%s'", testChart.CollectorHostname),
+				fmt.Sprintf("WHERE host.name like '%s'", testChart.NrQueryHostNamePattern),
 				"5 minutes ago",
 			)
 			client := nr.NewClient()

--- a/test/e2e/util/chart/nr_backend.go
+++ b/test/e2e/util/chart/nr_backend.go
@@ -1,14 +1,23 @@
 package chart
 
-import envutil "test/e2e/util/env"
+import (
+	"fmt"
+	envutil "test/e2e/util/env"
+)
 
 type NrBackendChart struct {
-	collectorHostname string
+	CollectorHostname string
 }
 
-func NewNrBackendChart(collectorHostname string) NrBackendChart {
+func NewNrBackendChart(testId string) NrBackendChart {
+	environmentName := "local"
+	if envutil.IsContinuousIntegration() {
+		environmentName = "ci"
+	}
+	collectorHostname := fmt.Sprintf("nr-otel-collector-%s-%s", environmentName, testId)
+
 	return NrBackendChart{
-		collectorHostname: collectorHostname,
+		CollectorHostname: collectorHostname,
 	}
 }
 
@@ -28,6 +37,6 @@ func (m *NrBackendChart) RequiredChartValues() map[string]string {
 		"image.tag":            envutil.GetImageTag(),
 		"secrets.nrBackendUrl": envutil.GetNrBackendUrl(),
 		"secrets.nrIngestKey":  envutil.GetNrIngestKey(),
-		"collector.hostname":   m.collectorHostname,
+		"collector.hostname":   m.CollectorHostname,
 	}
 }

--- a/test/e2e/util/spec/on_host.go
+++ b/test/e2e/util/spec/on_host.go
@@ -96,7 +96,7 @@ var testCases = []TestCase{
 			Name: "system.cpu.load_average.15m",
 		},
 		Assertions: []assert.NrAssertion{
-			{AggregationFunction: "max", ComparisonOperator: ">", Threshold: 0},
+			{AggregationFunction: "max", ComparisonOperator: ">=", Threshold: 0},
 		}},
 	{
 		Name: "host receiver memory.usage cached",
@@ -302,4 +302,20 @@ var testCases = []TestCase{
 
 func GetOnHostTestCases() []TestCase {
 	return testCases
+}
+
+func GetOnHostTestCasesWithout(excludedMetric []string) []TestCase {
+	var filteredTestCases []TestCase
+	for _, testCase := range testCases {
+		included := true
+		for _, skippedMetric := range excludedMetric {
+			if testCase.Metric.Name == skippedMetric {
+				included = false
+			}
+		}
+		if included {
+			filteredTestCases = append(filteredTestCases, testCase)
+		}
+	}
+	return filteredTestCases
 }

--- a/test/e2e/util/test/hostname.go
+++ b/test/e2e/util/test/hostname.go
@@ -1,0 +1,15 @@
+package test
+
+import "fmt"
+
+func NewHostNamePrefix(envName string, deployId string, hostType string) string {
+	// only a prefix as helm chart appends hostId
+	return fmt.Sprintf("%s-%s-%s", envName, deployId, hostType)
+}
+
+const Wildcard = "%"
+
+func NewNrQueryHostNamePattern(envName string, deployId string, hostType string) string {
+	hostId := Wildcard
+	return fmt.Sprintf("%s-%s-%s-%s", envName, deployId, hostType, hostId)
+}

--- a/test/e2e/util/test/test.go
+++ b/test/e2e/util/test/test.go
@@ -8,24 +8,46 @@ import (
 )
 
 const (
-	slowOnly = "slowOnly"
-	fastOnly = "fastOnly"
+	fastOnly    = "fastOnly"
+	slowOnly    = "slowOnly"
+	nightlyOnly = "nightlyOnly"
 )
 
-func TagAsSlowTest(t *testing.T) {
-	if isModeEnabled(fastOnly) {
-		t.Skip("Skipping slow test: ", t.Name())
-	}
-}
+var onlyModes = []string{fastOnly, slowOnly, nightlyOnly}
 
 func TagAsFastTest(t *testing.T) {
-	if isModeEnabled(slowOnly) {
+	if isAnyModeOf(allOnlyModesExcept(fastOnly)) {
 		t.Skip("Skipping fast test: ", t.Name())
 	}
 }
 
-func isModeEnabled(mode string) bool {
-	return strings.Contains(envutil.GetTestMode(), mode)
+func TagAsSlowTest(t *testing.T) {
+	if isAnyModeOf(allOnlyModesExcept(slowOnly)) {
+		t.Skip("Skipping slow test: ", t.Name())
+	}
+}
+
+func TagAsNightlyTest(t *testing.T) {
+	if isAnyModeOf(allOnlyModesExcept(nightlyOnly)) {
+		t.Skip("Skipping nightly test: ", t.Name())
+	}
+}
+
+func isAnyModeOf(modes []string) bool {
+	result := false
+	for _, mode := range modes {
+		result = result || strings.Contains(envutil.GetTestMode(), mode)
+	}
+	return result
+}
+func allOnlyModesExcept(filterOut string) []string {
+	var result []string
+	for _, onlyMode := range onlyModes {
+		if onlyMode != filterOut {
+			result = append(result, onlyMode)
+		}
+	}
+	return result
 }
 
 func NewTestId() string {

--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -1,0 +1,66 @@
+locals {
+  collector_reported_hostname = "${var.test_environment}-${var.deploy_id}-ec2_ubuntu24_04-0"
+}
+
+data "aws_ami" "ubuntu24_04" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+data "aws_vpc" "ec2_vpc" {
+  id = var.vpc_id
+}
+
+data "aws_subnets" "private_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
+  filter {
+    name   = "tag:Name"
+    values = ["*private*"]
+  }
+}
+
+resource "aws_security_group" "ec2_allow_all_egress" {
+  name        = "nightly-ec2-all-egress"
+  description = "Allow all outbound traffic"
+  vpc_id      = data.aws_vpc.ec2_vpc.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "ubuntu24_04" {
+  ami                    = data.aws_ami.ubuntu24_04.id
+  instance_type          = "t2.micro"
+  subnet_id              = data.aws_subnets.private_subnets.ids[0]
+  vpc_security_group_ids = [aws_security_group.ec2_allow_all_egress.id]
+
+  user_data = <<-EOF
+              #!/bin/bash
+              export DEBIAN_FRONTEND=noninteractive
+              curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | gpg --dearmor -o /usr/share/keyrings/newrelic-infra.gpg
+              printf '%s\n' 'deb [signed-by=/usr/share/keyrings/newrelic-infra.gpg] http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt noble main' | tee /etc/apt/sources.list.d/newrelic-infra.list
+              apt-get update
+              apt-get install nr-otel-collector=${var.collector_version}
+              echo 'NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}' >> /etc/nr-otel-collector/nr-otel-collector.conf
+              echo "OTEL_RESOURCE_ATTRIBUTES='host.name=${local.collector_reported_hostname}'" >> /etc/nr-otel-collector/nr-otel-collector.conf
+              systemctl reload-or-restart nr-otel-collector.service
+              EOF
+}

--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -1,5 +1,6 @@
 locals {
   collector_reported_hostname = "${var.test_environment}-${var.deploy_id}-ec2_ubuntu24_04-0"
+  collector_version_specifier = "${var.collector_version == "" ? "" : "="}${var.collector_version}"
 }
 
 data "aws_ami" "ubuntu24_04" {
@@ -54,11 +55,18 @@ resource "aws_instance" "ubuntu24_04" {
 
   user_data = <<-EOF
               #!/bin/bash
+              echo 'Configuring swap file to ensure system.paging.usage metric gets published'
+              dd if=/dev/zero of=/swapfile bs=1M count=128
+              chmod 600 /swapfile
+              mkswap /swapfile
+              swapon /swapfile
+              swapon -s
+              echo 'Installing Collector'
               export DEBIAN_FRONTEND=noninteractive
               curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | gpg --dearmor -o /usr/share/keyrings/newrelic-infra.gpg
               printf '%s\n' 'deb [signed-by=/usr/share/keyrings/newrelic-infra.gpg] http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt noble main' | tee /etc/apt/sources.list.d/newrelic-infra.list
               apt-get update
-              apt-get install nr-otel-collector=${var.collector_version}
+              apt-get install nr-otel-collector${local.collector_version_specifier}
               echo 'NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}' >> /etc/nr-otel-collector/nr-otel-collector.conf
               echo "OTEL_RESOURCE_ATTRIBUTES='host.name=${local.collector_reported_hostname}'" >> /etc/nr-otel-collector/nr-otel-collector.conf
               systemctl reload-or-restart nr-otel-collector.service

--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -1,14 +1,27 @@
 locals {
-  collector_reported_hostname = "${var.test_environment}-${var.deploy_id}-ec2_ubuntu24_04-0"
+  collector_reported_hostname_prefix = "${var.test_environment}-${var.deploy_id}"
+  instance_config = [
+    {
+      hostname_suffix    = "ec2_ubuntu22_04-0"
+      release_verion     = "22.04"
+      release_short_name = "jammy"
+    },
+    {
+      hostname_suffix    = "ec2_ubuntu24_04-0"
+      release_verion     = "24.04"
+      release_short_name = "noble"
+    },
+  ]
   collector_version_specifier = "${var.collector_version == "" ? "" : "="}${var.collector_version}"
 }
 
-data "aws_ami" "ubuntu24_04" {
+data "aws_ami" "ubuntu_ami" {
+  count       = length(local.instance_config)
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd*/ubuntu-${local.instance_config[count.index].release_short_name}-${local.instance_config[count.index].release_verion}-amd64-server-*"]
   }
 
   filter {
@@ -47,11 +60,62 @@ resource "aws_security_group" "ec2_allow_all_egress" {
   }
 }
 
-resource "aws_instance" "ubuntu24_04" {
-  ami                    = data.aws_ami.ubuntu24_04.id
+resource "aws_iam_role" "ec2_role" {
+  name = "ec2_s3_read_access_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+  permissions_boundary = var.permission_boundary
+}
+
+
+resource "aws_iam_policy" "s3_nr_releases_read_policy" {
+  name = "s3_read_policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.releases_bucket_name}",
+          "arn:aws:s3:::${var.releases_bucket_name}/*",
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "s3_read_policy" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.s3_nr_releases_read_policy.arn
+}
+
+resource "aws_iam_instance_profile" "s3_read_access" {
+  name = "ec2-s3-nr-releases-read-access"
+  role = aws_iam_role.ec2_role.name
+}
+
+resource "aws_instance" "ubuntu" {
+  count                  = length(local.instance_config)
+  ami                    = data.aws_ami.ubuntu_ami[count.index].id
   instance_type          = "t2.micro"
   subnet_id              = data.aws_subnets.private_subnets.ids[0]
   vpc_security_group_ids = [aws_security_group.ec2_allow_all_egress.id]
+  iam_instance_profile   = aws_iam_instance_profile.s3_read_access.name
+
 
   user_data = <<-EOF
               #!/bin/bash
@@ -61,14 +125,23 @@ resource "aws_instance" "ubuntu24_04" {
               mkswap /swapfile
               swapon /swapfile
               swapon -s
+              ################################################
               echo 'Installing Collector'
               export DEBIAN_FRONTEND=noninteractive
-              curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | gpg --dearmor -o /usr/share/keyrings/newrelic-infra.gpg
-              printf '%s\n' 'deb [signed-by=/usr/share/keyrings/newrelic-infra.gpg] http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt noble main' | tee /etc/apt/sources.list.d/newrelic-infra.list
-              apt-get update
-              apt-get install nr-otel-collector${local.collector_version_specifier}
-              echo 'NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}' >> /etc/nr-otel-collector/nr-otel-collector.conf
-              echo "OTEL_RESOURCE_ATTRIBUTES='host.name=${local.collector_reported_hostname}'" >> /etc/nr-otel-collector/nr-otel-collector.conf
-              systemctl reload-or-restart nr-otel-collector.service
+              apt update
+              apt install unzip
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+              unzip -q awscliv2.zip
+              ./aws/install
+              deb_package_basepath='s3://${var.releases_bucket_name}/opentelemetry-collector-releases/${var.collector_version}/'
+              latest_deb_package_filename=$(aws s3 ls $${deb_package_basepath} | sort -r | grep 'amd64.deb' | awk '{print $NF}')
+              echo "Installing collector from: $${deb_package_basepath}$${latest_deb_package_filename}"
+              aws s3 cp "$${deb_package_basepath}$${latest_deb_package_filename}" /tmp/collector.deb
+              dpkg -i /tmp/collector.deb
+              ################################################
+              echo 'Configuring Collector'
+              echo 'NEW_RELIC_LICENSE_KEY=${var.nr_ingest_key}' >> /etc/${var.collector_distro}/${var.collector_distro}.conf
+              echo "OTEL_RESOURCE_ATTRIBUTES='host.name=${local.collector_reported_hostname_prefix}-${local.instance_config[count.index].hostname_suffix}'" >> /etc/${var.collector_distro}/${var.collector_distro}.conf
+              systemctl reload-or-restart ${var.collector_distro}.service
               EOF
 }

--- a/test/terraform/modules/ec2/vars.tf
+++ b/test/terraform/modules/ec2/vars.tf
@@ -1,3 +1,12 @@
+variable "permission_boundary" {
+  description = "ARN of the IAM policy that is used to set the permissions boundary for the IAM roles created by this module"
+  type        = string
+}
+
+variable "releases_bucket_name" {
+  type = string
+}
+
 variable "test_environment" {
   type        = string
   description = "Name of test environment to distinguish entities"
@@ -5,8 +14,8 @@ variable "test_environment" {
 }
 
 variable "deploy_id" {
-    type        = string
-    description = "An id to uniquely identify a deployment to an environment, e.g. for change tracking"
+  type        = string
+  description = "An id to uniquely identify a deployment to an environment, e.g. for change tracking"
 }
 
 variable "vpc_id" {
@@ -20,8 +29,14 @@ variable "nr_ingest_key" {
   sensitive   = true
 }
 
+variable "collector_distro" {
+  description = "Name of the distribution of NRDOT to install"
+  type        = string
+  default     = "nr-otel-collector"
+}
+
 variable "collector_version" {
   description = "Version of nr-otel-collector to install"
   type        = string
-  default     = ""
+  default     = "nightly"
 }

--- a/test/terraform/modules/ec2/vars.tf
+++ b/test/terraform/modules/ec2/vars.tf
@@ -23,4 +23,5 @@ variable "nr_ingest_key" {
 variable "collector_version" {
   description = "Version of nr-otel-collector to install"
   type        = string
+  default     = ""
 }

--- a/test/terraform/modules/ec2/vars.tf
+++ b/test/terraform/modules/ec2/vars.tf
@@ -1,0 +1,26 @@
+variable "test_environment" {
+  type        = string
+  description = "Name of test environment to distinguish entities"
+  default     = "nightly"
+}
+
+variable "deploy_id" {
+    type        = string
+    description = "An id to uniquely identify a deployment to an environment, e.g. for change tracking"
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC where the instance will be deployed to (in one of the private subnets)"
+  type        = string
+}
+
+variable "nr_ingest_key" {
+  description = "New Relic ingest license key"
+  type        = string
+  sensitive   = true
+}
+
+variable "collector_version" {
+  description = "Version of nr-otel-collector to install"
+  type        = string
+}

--- a/test/terraform/modules/eks_cluster/main.tf
+++ b/test/terraform/modules/eks_cluster/main.tf
@@ -1,5 +1,4 @@
 locals {
-  iam_role_permissions_boundary = "arn:aws:iam::${var.account_id}:policy/resource-provisioner-boundary"
 
   # We need to ensure we don't attempt to use any of the disallowed zones:
   # https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html
@@ -45,7 +44,7 @@ module "vpc" {
   # https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#single-nat-gateway
   single_nat_gateway = true
 
-  vpc_flow_log_permissions_boundary = local.iam_role_permissions_boundary
+  vpc_flow_log_permissions_boundary = var.permission_boundary
 }
 
 
@@ -63,10 +62,10 @@ module "eks_cluster" {
   subnet_ids = module.vpc.private_subnets
 
   enable_cluster_creator_admin_permissions = true
-  iam_role_permissions_boundary            = local.iam_role_permissions_boundary
+  iam_role_permissions_boundary            = var.permission_boundary
 
   eks_managed_node_group_defaults = {
-    iam_role_permissions_boundary = local.iam_role_permissions_boundary
+    iam_role_permissions_boundary = var.permission_boundary
 
     instance_types = ["m5.large"]
 

--- a/test/terraform/modules/eks_cluster/outputs.tf
+++ b/test/terraform/modules/eks_cluster/outputs.tf
@@ -13,3 +13,7 @@ output "cluster_certificate_authority_data" {
 output "cluster_iam_role_arn" {
   value = module.eks_cluster.cluster_iam_role_arn
 }
+
+output "eks_vpc_id" {
+  value = module.vpc.vpc_id
+}

--- a/test/terraform/modules/eks_cluster/vars.tf
+++ b/test/terraform/modules/eks_cluster/vars.tf
@@ -3,7 +3,7 @@ variable "name" {
   type        = string
 }
 
-variable "account_id" {
-  description = "account id"
+variable "permission_boundary" {
+  description = "ARN of the IAM policy that is used to set the permissions boundary for the IAM roles created by this module"
   type        = string
 }

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -3,6 +3,8 @@ locals {
     for _, v in fileset(path.module, "../../../distributions/**") :
     regex("../../../distributions/([^/]*).*", dirname(v))
   ])))
+  releases_bucket_name                            = "nr-releases"
+  required_permissions_boundary_arn_for_new_roles = "arn:aws:iam::${var.aws_account_id}:policy/resource-provisioner-boundary"
 }
 
 data "aws_vpc" "this" {
@@ -14,7 +16,7 @@ module "ci_e2e_cluster" {
   source = "../modules/eks_cluster"
 
   name       = "aws-ci-e2etest"
-  account_id = var.aws_account_id
+  permission_boundary = local.required_permissions_boundary_arn_for_new_roles
 }
 
 data "aws_caller_identity" "current" {}
@@ -35,7 +37,7 @@ module "ecr" {
   repository_image_tag_mutability = "MUTABLE"
 
   repository_read_write_access_arns = [data.aws_iam_session_context.current.issuer_arn]
-  repository_read_access_arns = [module.ci_e2e_cluster.cluster_iam_role_arn]
+  repository_read_access_arns       = [module.ci_e2e_cluster.cluster_iam_role_arn]
 
   repository_lifecycle_policy = jsonencode({
     rules = [
@@ -43,10 +45,10 @@ module "ecr" {
         rulePriority = 1,
         description  = "Keep last 10 nightly images",
         selection = {
-          tagStatus   = "tagged",
+          tagStatus     = "tagged",
           tagPrefixList = ["nightly"],
-          countType   = "imageCountMoreThan",
-          countNumber = 10
+          countType     = "imageCountMoreThan",
+          countNumber   = 10
         },
         action = {
           type = "expire"
@@ -59,7 +61,7 @@ module "ecr" {
 module "s3_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
 
-  bucket = "nr-releases"
+  bucket = local.releases_bucket_name
   acl    = "private"
 
   control_object_ownership = true
@@ -120,9 +122,13 @@ resource "helm_release" "ci_e2e_nightly" {
 }
 
 module "ci_e2e_ec2" {
-  source        = "../modules/ec2"
-  nr_ingest_key = var.nr_ingest_key
+  source               = "../modules/ec2"
+  releases_bucket_name = local.releases_bucket_name
+  nr_ingest_key        = var.nr_ingest_key
   # reuse vpc to avoid having to pay for second NAT gateway for this simple use case
-  vpc_id    = module.ci_e2e_cluster.eks_vpc_id
-  deploy_id = random_string.deploy_id.result
+  vpc_id              = module.ci_e2e_cluster.eks_vpc_id
+  deploy_id           = random_string.deploy_id.result
+  # TODO: using sticky version until we have nightly-labeled binaries setup
+  collector_version   = "0.8.7"
+  permission_boundary = local.required_permissions_boundary_arn_for_new_roles
 }

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -114,17 +114,15 @@ resource "helm_release" "ci_e2e_nightly" {
   }
 
   set {
-    name = "collector.hostname"
+    name  = "collector.hostname"
     value = "${var.test_environment}-${random_string.deploy_id.result}-k8s_node"
   }
 }
 
 module "ci_e2e_ec2" {
-  source = "../modules/ec2"
-  nr_ingest_key  =  var.nr_ingest_key
+  source        = "../modules/ec2"
+  nr_ingest_key = var.nr_ingest_key
   # reuse vpc to avoid having to pay for second NAT gateway for this simple use case
-  vpc_id = module.ci_e2e_cluster.eks_vpc_id
+  vpc_id    = module.ci_e2e_cluster.eks_vpc_id
   deploy_id = random_string.deploy_id.result
-  # TODO: use nightly instead
-  collector_version = "0.8.5"
 }

--- a/test/terraform/permanent/providers.tf
+++ b/test/terraform/permanent/providers.tf
@@ -28,13 +28,6 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::${var.aws_account_id}:role/resource-provisioner"
   }
-  #   default_tags {
-  #     tags = {
-  #       "Terraform"    = "true"
-  #       "Repo"         = "newrelic-opentelemetry-collector-releases"
-  #       "TerraformDir" = "permanent"
-  #     }
-  #   }
 }
 
 provider "helm" {

--- a/test/terraform/permanent/providers.tf
+++ b/test/terraform/permanent/providers.tf
@@ -21,19 +21,26 @@ terraform {
 }
 
 provider "aws" {
-  region = var.aws_region
+  region              = var.aws_region
   allowed_account_ids = [var.aws_account_id]
   # expect AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as env vars
 
   assume_role {
     role_arn = "arn:aws:iam::${var.aws_account_id}:role/resource-provisioner"
   }
+  #   default_tags {
+  #     tags = {
+  #       "Terraform"    = "true"
+  #       "Repo"         = "newrelic-opentelemetry-collector-releases"
+  #       "TerraformDir" = "permanent"
+  #     }
+  #   }
 }
 
 provider "helm" {
   kubernetes {
-    host  = module.ci_e2e_cluster.cluster_endpoint
+    host                   = module.ci_e2e_cluster.cluster_endpoint
     cluster_ca_certificate = base64decode(module.ci_e2e_cluster.cluster_certificate_authority_data)
-    token = data.aws_eks_cluster_auth.this.token
+    token                  = data.aws_eks_cluster_auth.this.token
   }
 }


### PR DESCRIPTION
### Summary
- Add EC2 instances running ubuntu 24.04 and 22.04 running collector to nightly test infra
- Add NRQL-based tests that assert that nightly test infra produces expected hostmetrics
  - `system.paging.usage`: requires a swapfile to be allocated, [added](https://repost.aws/knowledge-center/ec2-memory-swap-file) it for EC2 but skip this test for k8s as the overhead of creating an AMI for k8s nodes to use seems to much to support this test case.
  - `system.cpu.load_average.15m`: [drops to 0](https://onenr.io/0LwGl9qm8R6) in idle for the EC2, so after running long enough this test would fail, thus I changed it to `>=0`. Alternative would be to add a load-generating script.

### Misc
#### Hostname changes
- Previous PR added `OTEL_RESOURCE_ATTRIBUTES` specifier to force predictable hostnames to be reported to NR. Added some structure to those names to enforce consistency across different test environments (local-dev1, local-dev2, ci, nightly) and host machines (k8s-node1, k8s-node2, ec2-ubuntu,...) 
  - Appended the node name to k8s nodes as the daemonset deploys the collector to multiple/different nodes, so using the same hostname doesn't make sense and also causes issues in the UI because two entities with the same hostname got created
  - Appended `-0` to ubuntu hosts to stick with the naming scheme. Could've also had the OS be the `hostId` but then we might have use cases of deploying the same OS multiple times, so I stuck with `-0` for now.

#### Removal of TestMain
- No longer use `TestMain` for test setup as test tagging/filtering should be the first logic to run to avoid errors due to missing env vars that are not necessary for the subsets of tests run, e.g. NR_INGEST_KEY not required for nightly tests. `testing.M` doesn't provide an API to skip a test, so it can't be used in the `testutil` package.

### Test
- Nightly tests specified in this PR don't pass yet because a) ec2 is not deployed yet and b) the eks node collector still uses the old host name. To ensure the tests do work, I temporarily deployed the EC2 and ran the tests using the old k8s hostname.