### PR TITLE
ci: enforce node-naming conventions

### DIFF
--- a/test/e2e/util/chart/nr_backend.go
+++ b/test/e2e/util/chart/nr_backend.go
@@ -24,8 +24,8 @@ func NewNrBackendChart(testId string) NrBackendChart {
 		}
 		environmentName = fmt.Sprintf("local_%s", user.Username)
 	}
-	hostNamePrefix := testutil.NewHostNamePrefix(environmentName, testId, "k8s-node")
-	hostNamePattern := testutil.NewNrQueryHostNamePattern(environmentName, testId, "k8s-node")
+	hostNamePrefix := testutil.NewHostNamePrefix(environmentName, testId, "k8s_node")
+	hostNamePattern := testutil.NewNrQueryHostNamePattern(environmentName, testId, "k8s_node")
 
 	return NrBackendChart{
 		collectorHostNamePrefix: hostNamePrefix,

--- a/test/terraform/permanent/vars.tf
+++ b/test/terraform/permanent/vars.tf
@@ -24,6 +24,6 @@ variable "nr_ingest_key" {
 variable "test_environment" {
   type        = string
   description = "Name of test environment to distinguish entities"
-  default     = "permanent"
+  default     = "nightly"
 }
 


### PR DESCRIPTION
### Summary
- Use `nightly` host name prefix for EKS nodes. Still using `permanent` which causes [nightly tests to fail](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/12914171239/job/36013128738#step:14:43).
- Replace `k8s-node` with `k8s_node` for consistency in regular ci tests
- [Current host names](https://onenr.io/0OwvdMG2yjv) reported to NR for reference
<img width="1487" alt="image" src="https://github.com/user-attachments/assets/308e322c-6a29-417c-8349-b7470c5c0725" />
