### PR TITLE
chore: prepare release 0.8.8

### DIFF
--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -2,7 +2,7 @@ dist:
   module: github.com/newrelic/opentelemetry-collector-releases/nr-otel-collector
   name: nr-otel-collector
   description: New Relic OpenTelemetry Collector
-  version: 0.8.7
+  version: 0.8.8
   output_path: ./_build
   otelcol_version: 0.112.0
 


### PR DESCRIPTION
### Summary
- Bumping version to then tag commit and publish `0.8.8`