### PR TITLE
ci: use v2 goreleaser args for prerelease

### DIFF
--- a/.github/workflows/ci-prerelease.yml
+++ b/.github/workflows/ci-prerelease.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --rm-dist --timeout 2h
+          args: release --clean --timeout 2h
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}


### PR DESCRIPTION
### Summary
- Fixes [failing prerelease of 0.8.8](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/12936144401/job/36081079822#step:9:23) by following [goreleaser upgrade docs](https://goreleaser.com/deprecations/#-rm-dist)