### PR TITLE
fix: skip nightly EC2 tests for paging.usage

### DIFF
--- a/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
+++ b/test/e2e/hostmetrics_nightly/hostmetrics_nightly_test.go
@@ -17,9 +17,13 @@ type systemUnderTest struct {
 
 var ec2Ubuntu22 = systemUnderTest{
 	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu22_04"),
+	// TODO: NR-362121
+	excludedMetrics: []string{"system.paging.usage"},
 }
 var ec2Ubuntu24 = systemUnderTest{
 	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "ec2_ubuntu24_04"),
+	// TODO: NR-362121
+	excludedMetrics: []string{"system.paging.usage"},
 }
 var k8sNode = systemUnderTest{
 	hostNamePattern: testutil.NewNrQueryHostNamePattern("nightly", testutil.Wildcard, "k8s_node"),


### PR DESCRIPTION
### Summary
- Disable nightly tests for `system.paging.usage` for EC2s until we have a better understanding on why the metrics stopped reporting. Most likely a test setup issue.