### PR TITLE
ci: support distro-dependent tests

### DIFF
--- a/test/charts/mocked_backend/Chart.yaml
+++ b/test/charts/mocked_backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: nrdot-mocked-backend
-description: A Helm chart for deploying nr-otel-collector as a DaemonSet writing to a Mock Backend for assertions in tests
+description: A Helm chart for deploying an nrdot collector as a DaemonSet writing to a Mock Backend for assertions in tests
 version: 0.1.0
 appVersion: "1.0"

--- a/test/charts/mocked_backend/templates/daemonset.yaml
+++ b/test/charts/mocked_backend/templates/daemonset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: &app nr-otel-collector
+  name: &app nrdot-collector
   labels:
     app: *app
 spec:

--- a/test/charts/mocked_backend/values.yaml
+++ b/test/charts/mocked_backend/values.yaml
@@ -3,5 +3,3 @@ image:
   tag: latest
   # Avoid accidentally pulling remote images in CI
   pullPolicy: Never
-
-resources: {}

--- a/test/charts/nr_backend/Chart.yaml
+++ b/test/charts/nr_backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: nrdot-nr-backend
-description: A Helm chart for deploying nr-otel-collector as a DaemonSet writing to New Relic
+description: A Helm chart for deploying an nrdot collector as a DaemonSet writing to New Relic
 version: 0.1.0
 appVersion: "1.0"

--- a/test/charts/nr_backend/templates/daemonset.yaml
+++ b/test/charts/nr_backend/templates/daemonset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: &app nr-otel-collector
+  name: &app nrdot-collector
   labels:
     app: *app
 spec:

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,6 +1,7 @@
 KIND_CLUSTER_NAME ?=e2etest
 K8S_CONTEXT_NAME=kind-${KIND_CLUSTER_NAME}
-IMAGE_REPO=newrelic/nr-otel-collector
+DISTRO ?=nr-otel-collector
+IMAGE_REPO=newrelic/${DISTRO}
 THIS_MAKEFILE_DIR := $(realpath $(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 ROOT_DIR := $(realpath $(THIS_MAKEFILE_DIR)/../..)
 
@@ -49,6 +50,7 @@ ci_test-nightly: ci_test
 ci_test:
 	cd ${THIS_MAKEFILE_DIR} && \
 	E2E_TEST__K8S_CONTEXT_NAME=${K8S_CONTEXT_NAME} \
+	E2E_TEST__DISTRO_TO_TEST=${DISTRO} \
 	E2E_TEST__IMAGE_TAG=${IMAGE_TAG} \
 	E2E_TEST__NR_BACKEND_URL=${NR_BACKEND_URL} \
 	E2E_TEST__NR_INGEST_KEY=${NR_INGEST_KEY} \
@@ -61,6 +63,8 @@ ci_test:
 ################
 #### LOCAL #####
 ################
+MOST_RECENT_IMAGE_TAG := $(shell docker images -a --filter 'reference=newrelic/${DISTRO}' '--format={{.CreatedAt}} {{.Tag}}' | sort -r | head -n1 | awk '{print $$NF}')
+
 .PHONY: local_create-cluster-if-not-exists
 local_create-cluster-if-not-exists:
 	kind get clusters | grep -q ${KIND_CLUSTER_NAME} \
@@ -70,18 +74,15 @@ local_create-cluster-if-not-exists:
 local_build-image:
 	cd $(ROOT_DIR) && goreleaser --snapshot --clean --skip=sign
 
-.PHONY: local_test
-# hardcode an image you build with local_build-image, then run this target to run tests against it
-local_test: IMAGE_TAG=insert_locally_available_tag_to_test_here
-local_test: local_create-cluster-if-not-exists ci_test
-
 .PHONY: local_test-fast
 local_test-fast: TEST_MODE=fastOnly
-local_test-fast: local_test
+local_test-fast: IMAGE_TAG=${MOST_RECENT_IMAGE_TAG}
+local_test-fast: local_create-cluster-if-not-exists ci_test-fast
 
 .PHONY: local_test-slow
 local_test-slow: TEST_MODE=slowOnly
-local_test-slow: local_test
+local_test-slow: IMAGE_TAG=${MOST_RECENT_IMAGE_TAG}
+local_test-slow: local_create-cluster-if-not-exists ci_test-slow
 
 .PHONY: local_helm-cleanup
 local_helm-cleanup:

--- a/test/e2e/util/chart/mocked_backend.go
+++ b/test/e2e/util/chart/mocked_backend.go
@@ -1,6 +1,9 @@
 package chart
 
-import utilenv "test/e2e/util/env"
+import (
+	"fmt"
+	envutil "test/e2e/util/env"
+)
 
 type MockedBackendChart struct {
 }
@@ -20,7 +23,8 @@ func (m *MockedBackendChart) Meta() Meta {
 
 func (m *MockedBackendChart) RequiredChartValues() map[string]string {
 	return map[string]string{
-		"image.tag": utilenv.GetImageTag(),
+		"image.repository": fmt.Sprintf("newrelic/%s", envutil.GetDistro()),
+		"image.tag":        envutil.GetImageTag(),
 	}
 }
 

--- a/test/e2e/util/chart/nr_backend.go
+++ b/test/e2e/util/chart/nr_backend.go
@@ -46,6 +46,7 @@ func (m *NrBackendChart) Meta() Meta {
 
 func (m *NrBackendChart) RequiredChartValues() map[string]string {
 	return map[string]string{
+		"image.repository":     fmt.Sprintf("newrelic/%s", envutil.GetDistro()),
 		"image.tag":            envutil.GetImageTag(),
 		"secrets.nrBackendUrl": envutil.GetNrBackendUrl(),
 		"secrets.nrIngestKey":  envutil.GetNrIngestKey(),

--- a/test/e2e/util/env/env.go
+++ b/test/e2e/util/env/env.go
@@ -9,6 +9,7 @@ import (
 const (
 	TestMode       = "E2E_TEST__TEST_MODE"
 	K8sContextName = "E2E_TEST__K8S_CONTEXT_NAME"
+	Distro         = "E2E_TEST__DISTRO_TO_TEST"
 	ImageTag       = "E2E_TEST__IMAGE_TAG"
 	NrBackendUrl   = "E2E_TEST__NR_BACKEND_URL"
 	NrIngestKey    = "E2E_TEST__NR_INGEST_KEY"
@@ -32,6 +33,10 @@ func GetTestMode() string {
 
 func GetK8sContextName() string {
 	return getEnvVar(K8sContextName)
+}
+
+func GetDistro() string {
+	return getEnvVar(Distro)
 }
 
 func GetImageTag() string {

--- a/test/e2e/util/k8s/k8s.go
+++ b/test/e2e/util/k8s/k8s.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"fmt"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,14 +10,19 @@ import (
 	"time"
 )
 
-func NewKubectlOptions(namespace string) *k8s.KubectlOptions {
+func NewKubectlOptions(namespacePrefix string) *k8s.KubectlOptions {
+	namespace := newTestNamespace(namespacePrefix, envutil.GetDistro())
 	contextName := envutil.GetK8sContextName()
 	return k8s.NewKubectlOptions(contextName, "", namespace)
 }
 
+func newTestNamespace(namespacePrefix string, distro string) string {
+	return fmt.Sprintf("%s-%s", namespacePrefix, distro)
+}
+
 func WaitForCollectorReady(tb testing.TB, kubectlOptions *k8s.KubectlOptions) corev1.Pod {
 	filters := metav1.ListOptions{
-		LabelSelector: "app=nr-otel-collector",
+		LabelSelector: "app=nrdot-collector",
 	}
 	k8s.WaitUntilNumPodsCreated(tb, kubectlOptions, filters, 1, 30, 10*time.Second)
 

--- a/test/e2e/util/test/hostname.go
+++ b/test/e2e/util/test/hostname.go
@@ -3,6 +3,7 @@ package test
 import "fmt"
 
 func NewHostNamePrefix(envName string, deployId string, hostType string) string {
+	// TODO: incorporate distro into hostname when generalizing nightly to support multiple distro
 	// only a prefix as helm chart appends hostId
 	return fmt.Sprintf("%s-%s-%s", envName, deployId, hostType)
 }
@@ -10,6 +11,7 @@ func NewHostNamePrefix(envName string, deployId string, hostType string) string 
 const Wildcard = "%"
 
 func NewNrQueryHostNamePattern(envName string, deployId string, hostType string) string {
+	// TODO: incorporate distro into hostname when generalizing nightly to support multiple distro
 	hostId := Wildcard
 	return fmt.Sprintf("%s-%s-%s-%s", envName, deployId, hostType, hostId)
 }


### PR DESCRIPTION
### Summary
- Generalize fast and slow tests to support running with a second distro published under the name `newrelic/$distro_name`.
- Nightly will be adjusted in a separate PR which will also generalize the hostname to incorporate the distro to avoid unintended overlap in queries. Post this PR this is technically the case for `slow` tests but as we still have only one distro, this is okay as a temporary state and can be addressed in the follow-up PR.

### Tests
- Tested by locally modifying `.goreleaser.yaml` to publish docker images to `newrelic/foobar` and running makefile with`DISTRO=foobar`.
- Running fast tests for two distros at the same time was successful 
<img width="987" alt="image" src="https://github.com/user-attachments/assets/16813925-b273-4c03-ae20-0f8779975f93" />

