### PR TITLE
ci: support skip nightly tests by distro/host

### DIFF
--- a/distributions/nr-otel-collector/test-spec.yaml
+++ b/distributions/nr-otel-collector/test-spec.yaml
@@ -1,0 +1,3 @@
+nightly:
+  ec2:
+    enabled: true

--- a/test/e2e/util/chart/chart.go
+++ b/test/e2e/util/chart/chart.go
@@ -1,10 +1,7 @@
 package chart
 
 import (
-	"fmt"
-	"os"
-	"path"
-	"strings"
+	testutil "test/e2e/util/test"
 )
 
 type Chart interface {
@@ -17,13 +14,5 @@ type Meta struct {
 }
 
 func (m Meta) ChartPath() string {
-	pwd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-	testDirPath := path.Clean(fmt.Sprintf("%s/../..", pwd))
-	if !strings.HasSuffix(testDirPath, "test") {
-		panic(fmt.Sprintf("Unexpected directory structure: %s should be the test dir containing the charts directory (pwd: %s)", testDirPath, pwd))
-	}
-	return path.Join(testDirPath, "charts", m.name)
+	return testutil.NewPathRelativeToRootDir("test/charts/" + m.name)
 }

--- a/test/e2e/util/chart/mocked_backend.go
+++ b/test/e2e/util/chart/mocked_backend.go
@@ -27,8 +27,3 @@ func (m *MockedBackendChart) RequiredChartValues() map[string]string {
 		"image.tag":        envutil.GetImageTag(),
 	}
 }
-
-func (m *MockedBackendChart) GetCollectorSelector() string {
-	//TODO implement me
-	panic("implement me")
-}

--- a/test/e2e/util/spec/nightly.go
+++ b/test/e2e/util/spec/nightly.go
@@ -1,0 +1,7 @@
+package spec
+
+type NightlySystemUnderTest struct {
+	HostNamePattern string
+	ExcludedMetrics []string
+	SkipIf          func(testSpec *TestSpec) bool
+}

--- a/test/e2e/util/spec/on_host.go
+++ b/test/e2e/util/spec/on_host.go
@@ -1,6 +1,8 @@
 package spec
 
-import "test/e2e/util/assert"
+import (
+	"test/e2e/util/assert"
+)
 
 type TestCase struct {
 	Name       string

--- a/test/e2e/util/spec/specfile.go
+++ b/test/e2e/util/spec/specfile.go
@@ -1,0 +1,34 @@
+package spec
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"os"
+	envutil "test/e2e/util/env"
+	testutil "test/e2e/util/test"
+)
+
+type TestSpec struct {
+	Nightly struct {
+		EC2 struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"ec2"`
+	} `yaml:"nightly"`
+}
+
+func LoadTestSpec() *TestSpec {
+	distro := envutil.GetDistro()
+	testSpecFile := testutil.NewPathRelativeToRootDir("distributions/" + distro + "/test-spec.yaml")
+	testSpecData, err := os.ReadFile(testSpecFile)
+	if err != nil {
+		panic(fmt.Errorf("failed to read test spec file: %w", err))
+	}
+
+	var testSpec TestSpec
+	err = yaml.Unmarshal(testSpecData, &testSpec)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal test spec: %w", err))
+	}
+
+	return &testSpec
+}

--- a/test/e2e/util/test/hostname.go
+++ b/test/e2e/util/test/hostname.go
@@ -1,17 +1,28 @@
 package test
 
-import "fmt"
+import (
+	"strings"
+	envutil "test/e2e/util/env"
+)
+
+const (
+	Wildcard                 = "%"
+	hostNameSegmentSeparator = "-"
+)
 
 func NewHostNamePrefix(envName string, deployId string, hostType string) string {
-	// TODO: incorporate distro into hostname when generalizing nightly to support multiple distro
+	distro := getNormalizedDistro()
 	// only a prefix as helm chart appends hostId
-	return fmt.Sprintf("%s-%s-%s", envName, deployId, hostType)
+	return strings.Join([]string{envName, deployId, distro, hostType}, hostNameSegmentSeparator)
 }
 
-const Wildcard = "%"
-
 func NewNrQueryHostNamePattern(envName string, deployId string, hostType string) string {
-	// TODO: incorporate distro into hostname when generalizing nightly to support multiple distro
+	distro := getNormalizedDistro()
 	hostId := Wildcard
-	return fmt.Sprintf("%s-%s-%s-%s", envName, deployId, hostType, hostId)
+	return strings.Join([]string{envName, deployId, distro, hostType, hostId}, hostNameSegmentSeparator)
+}
+
+func getNormalizedDistro() string {
+	// solely to improve readability - no technical necessity
+	return strings.Replace(envutil.GetDistro(), hostNameSegmentSeparator, "_", -1)
 }

--- a/test/e2e/util/test/path.go
+++ b/test/e2e/util/test/path.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+func NewPathRelativeToRootDir(pathFromRoot string) string {
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	rootDir := path.Clean(fmt.Sprintf("%s/../../..", pwd))
+
+	if _, err := os.Stat(path.Join(rootDir, ".github")); err != nil {
+		panic(fmt.Errorf("unexpected directory structure: %s should be the root dir (pwd: %s) but encountered error %w", rootDir, pwd, err))
+	}
+	var result = rootDir
+	for _, segment := range strings.Split(pathFromRoot, "/") {
+		result = path.Join(result, segment)
+	}
+	return result
+}

--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -1,5 +1,5 @@
 locals {
-  collector_reported_hostname_prefix = "${var.test_environment}-${var.deploy_id}"
+  collector_reported_hostname_prefix = "${var.test_environment}-${var.deploy_id}-${var.collector_distro}"
   instance_config = [
     {
       hostname_suffix    = "ec2_ubuntu22_04-0"

--- a/test/terraform/modules/ec2/vars.tf
+++ b/test/terraform/modules/ec2/vars.tf
@@ -32,7 +32,6 @@ variable "nr_ingest_key" {
 variable "collector_distro" {
   description = "Name of the distribution of NRDOT to install"
   type        = string
-  default     = "nr-otel-collector"
 }
 
 variable "collector_version" {


### PR DESCRIPTION
### Summary
- Introduce per-distro `test-spec.yaml` to toggle nightly tests. The idea was that this could be a starting point to also incorporate features like skipping specific metrics and/or listing the metrics to test in the first place.
   - Corresponding nightly test infra is only deployed when enabled, e.g. `k8s` distro will not need to run on bare EC2s, so the EC2s shouldn't be deployed in the first place.
   - Skipped toggling k8s_node tests for now as both `host` and `k8s` will need to support it and when we move to testing `k8s` in host/gateway mode, we'll need to provide more finegrained control at which point we can incorporate skipping parts of it for the `host` distro
- Incorporate distro into
    - k8s namespace to minimize interference
    - the hostname to 'namespace' data in NR

### Tests
- [tf plan](https://github.com/newrelic/opentelemetry-collector-releases/actions/runs/12997624550/job/36249015987?pr=201#step:5:1237) looks good