### PR TITLE
feat: add nrdot-collector-host distro

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         dist:
           - nr-otel-collector
+          - nrdot-collector-host
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TOOLS_BIN_NAMES := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(shell echo $(TOOLS_
 GO_LICENCE_DETECTOR        := $(TOOLS_BIN_DIR)/go-licence-detector
 GO_LICENCE_DETECTOR_CONFIG   := $(SRC_ROOT)/internal/assets/license/rules.json
 
-DISTRIBUTIONS ?= "nr-otel-collector,nrdot-collector-k8s"
+DISTRIBUTIONS ?= "nr-otel-collector,nrdot-collector-host"
 
 ci: check build licenses-check
 check: ensure-goreleaser-up-to-date

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -1,0 +1,8 @@
+.PHONY: ci
+ci:
+	act -W .github/workflows/ci.yaml
+
+ci_custom_matrix:
+	@# repeat --matrix arg for multiple distros
+	act -W .github/workflows/ci.yaml \
+		--matrix dist:nrdot-collector-host

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 <a href="https://opensource.newrelic.com/oss-category/#community-project"><picture><source media="(prefers-color-scheme: dark)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/dark/Community_Project.png"><source media="(prefers-color-scheme: light)" srcset="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Project.png"><img alt="New Relic Open Source community project banner." src="https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Project.png"></picture></a>
 
-# New Relic OpenTelemetry collector releases
+# New Relic Distribution of OpenTelemetry (NRDOT) Releases 
 
-This repository assembles New Relic's OpenTelemetry Collector distributions. All generated assets are available in the corresponding Github release page.
+This repository assembles various [custom distributions](https://opentelemetry.io/docs/collector/distributions/#custom-distributions) of the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) focused on specific use cases and pre-configured to work with NewRelic out-of-the-box.
+
+Generated assets are available in the corresponding Github release page and as docker images published within the [newrelic organization on Docker Hub](https://hub.docker.com/u/newrelic).
 
 Current list of distributions:
 
-- [New Relic OpenTelemetry Collector](./distributions/nr-otel-collector/)
+- [nr-otel-collector](./distributions/nr-otel-collector/): (Deprecated) legacy general-purpose distribution
+- [nrdot-collector-host](./distributions/nrdot-collector-host/): distribution focused on monitoring host metrics and logs
 
 ## Support
 

--- a/cmd/goreleaser/internal/configure.go
+++ b/cmd/goreleaser/internal/configure.go
@@ -28,8 +28,9 @@ import (
 const (
 	ArmArch = "arm"
 
-	HostDistro = "nr-otel-collector"
-	K8sDistro  = "nrdot-collector-k8s"
+	LegacyDistro = "nr-otel-collector"
+	HostDistro   = "nrdot-collector-host"
+	K8sDistro    = "nrdot-collector-k8s"
 
 	DockerHub   = "newrelic"
 	EnvRegistry = "{{ .Env.REGISTRY }}"
@@ -43,7 +44,7 @@ var (
 	NightlyImagePrefixes = []string{EnvRegistry}
 
 	Architectures      = []string{"amd64", "arm64"}
-	DefaultConfigDists = map[string]bool{HostDistro: true}
+	DefaultConfigDists = map[string]bool{LegacyDistro: true, HostDistro: true}
 	K8sDockerSkipArchs = map[string]bool{"arm": true, "386": true}
 	K8sGoos            = []string{"linux"}
 	K8sArchs           = []string{"amd64", "arm64"}

--- a/distributions/README.md
+++ b/distributions/README.md
@@ -1,0 +1,18 @@
+# Collector Distributions
+
+## Installation
+
+### General
+
+#### Environment variables
+- `NEW_RELIC_LICENSE_KEY`: New Relic ingest key.
+- `NEW_RELIC_MEMORY_LIMIT_MIB`: Maximum amount of memory to be used. 
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: New Relic OTLP endpoint to export metrics to, see [official docs](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)
+
+### Components
+
+The full list of components is available in the respective `manifest.yaml`
+
+### Configuration
+
+The default configuration is `config.yaml` which is embedded in the `Dockerfile` and any OS-specific packaging (if available).

--- a/distributions/nr-otel-collector/Makefile
+++ b/distributions/nr-otel-collector/Makefile
@@ -1,1 +1,0 @@
-include ../../Makefile.common

--- a/distributions/nr-otel-collector/README.md
+++ b/distributions/nr-otel-collector/README.md
@@ -1,7 +1,5 @@
-# New Relic OpenTelemetry Collector Distro
+# nr-otel-collector
 
-TODO
+Note: See [general README](../README.md) for information that applies to all distributions.
 
-## Components
-
-The full list of components is available in the [manifest](manifest.yaml)
+The legacy general-purpose distribution of the NRDOT collector. Will be deprecated in favor of more specialized distributions.

--- a/distributions/nr-otel-collector/config.yaml
+++ b/distributions/nr-otel-collector/config.yaml
@@ -1,12 +1,3 @@
-# The following environment variables require manual modification:
-# - NEW_RELIC_LICENSE_KEY: New Relic ingest key.
-
-# If the collector is not installed through a package manager, the following
-# environment variables need to be set:
-# - NEW_RELIC_MEMORY_LIMIT_MIB: Maximum amount of memory to be used. (default: 100)
-# - OTEL_EXPORTER_OTLP_ENDPOINT: New Relic OTLP endpoint to export metrics to (see: https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)
-
-# Keep host monitoring configuration in sync with: https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/other-examples/collector/host-monitoring/k8s/collector.yaml
 extensions:
   health_check:
 

--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -41,11 +41,11 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.118.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.18.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.18.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.18.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.18.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.18.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.24.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.24.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.24.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.24.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.24.0
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:

--- a/distributions/nrdot-collector-host/.goreleaser-nightly.yaml
+++ b/distributions/nrdot-collector-host/.goreleaser-nightly.yaml
@@ -1,0 +1,138 @@
+version: 2
+project_name: nrdot-collector-releases-nightly
+builds:
+  - id: nrdot-collector-host
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    dir: _build
+    binary: nrdot-collector-host
+    ldflags:
+      - -s
+      - -w
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+archives:
+  - id: nrdot-collector-host
+    builds:
+      - nrdot-collector-host
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+nfpms:
+  - file_name_template: '{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{- if not (eq (filter .ConventionalFileName "\\.rpm$") "") }}{{- replace .Arch "amd64" "x86_64" }}{{- else }}{{- .Arch }}{{- end }}{{- with .Arm }}v{{ . }}{{- end }}{{- with .Mips }}_{{ . }}{{- end }}{{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{- end }}'
+    package_name: nrdot-collector-host
+    contents:
+      - src: nrdot-collector-host.service
+        dst: /lib/systemd/system/nrdot-collector-host.service
+      - src: nrdot-collector-host.conf
+        dst: /etc/nrdot-collector-host/nrdot-collector-host.conf
+        type: config|noreplace
+      - src: config.yaml
+        dst: /etc/nrdot-collector-host/config.yaml
+        type: config
+    scripts:
+      preinstall: preinstall.sh
+      postinstall: postinstall.sh
+      preremove: preremove.sh
+    rpm:
+      signature:
+        key_file: '{{ .Env.GPG_KEY_PATH }}'
+    deb:
+      signature:
+        key_file: '{{ .Env.GPG_KEY_PATH }}'
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
+    id: nrdot-collector-host
+    builds:
+      - nrdot-collector-host
+    formats:
+      - deb
+      - rpm
+    maintainer: New Relic <caos-team@newrelic.com>
+    description: NRDOT Collector - nrdot-collector-host
+    license: Apache 2.0
+snapshot:
+  version_template: '{{ incpatch .Version }}-SNAPSHOT-{{.ShortCommit}}'
+checksum:
+  name_template: '{{ .ArtifactName }}.sum'
+  algorithm: sha256
+  split: true
+dockers:
+  - goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    image_templates:
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:{{ .Version }}-nightly-amd64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:nightly-amd64'
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+  - goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    image_templates:
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:{{ .Version }}-nightly-arm64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:nightly-arm64'
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --platform=linux/arm64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+docker_manifests:
+  - name_template: '{{ .Env.REGISTRY }}/nrdot-collector-host:nightly'
+    image_templates:
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:nightly-amd64'
+      - '{{ .Env.REGISTRY }}/nrdot-collector-host:nightly-arm64'
+blobs:
+  - bucket: nr-releases
+    provider: s3
+    region: us-east-1
+    directory: nrdot-collector-releases/nrdot-collector-host/nightly
+changelog:
+  disable: "true"
+signs:
+  - args:
+      - --batch
+      - -u
+      - '{{ .Env.GPG_FINGERPRINT }}'
+      - --output
+      - ${signature}
+      - --detach-sign
+      - ${artifact}
+    signature: ${artifact}.sig
+    artifacts: all
+    certificate: ${artifact}.pem
+docker_signs:
+  - args:
+      - sign
+      - ${artifact}
+    artifacts: all

--- a/distributions/nrdot-collector-host/.goreleaser.yaml
+++ b/distributions/nrdot-collector-host/.goreleaser.yaml
@@ -1,0 +1,142 @@
+version: 2
+project_name: nrdot-collector-releases
+builds:
+  - id: nrdot-collector-host
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    dir: _build
+    binary: nrdot-collector-host
+    ldflags:
+      - -s
+      - -w
+    flags:
+      - -trimpath
+    env:
+      - CGO_ENABLED=0
+archives:
+  - id: nrdot-collector-host
+    builds:
+      - nrdot-collector-host
+    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}'
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+nfpms:
+  - file_name_template: '{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{- if not (eq (filter .ConventionalFileName "\\.rpm$") "") }}{{- replace .Arch "amd64" "x86_64" }}{{- else }}{{- .Arch }}{{- end }}{{- with .Arm }}v{{ . }}{{- end }}{{- with .Mips }}_{{ . }}{{- end }}{{- if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{- end }}'
+    package_name: nrdot-collector-host
+    contents:
+      - src: nrdot-collector-host.service
+        dst: /lib/systemd/system/nrdot-collector-host.service
+      - src: nrdot-collector-host.conf
+        dst: /etc/nrdot-collector-host/nrdot-collector-host.conf
+        type: config|noreplace
+      - src: config.yaml
+        dst: /etc/nrdot-collector-host/config.yaml
+        type: config
+    scripts:
+      preinstall: preinstall.sh
+      postinstall: postinstall.sh
+      preremove: preremove.sh
+    rpm:
+      signature:
+        key_file: '{{ .Env.GPG_KEY_PATH }}'
+    deb:
+      signature:
+        key_file: '{{ .Env.GPG_KEY_PATH }}'
+    overrides:
+      rpm:
+        dependencies:
+          - /bin/sh
+    id: nrdot-collector-host
+    builds:
+      - nrdot-collector-host
+    formats:
+      - deb
+      - rpm
+    maintainer: New Relic <caos-team@newrelic.com>
+    description: NRDOT Collector - nrdot-collector-host
+    license: Apache 2.0
+snapshot:
+  version_template: '{{ incpatch .Version }}-SNAPSHOT-{{.ShortCommit}}'
+checksum:
+  name_template: '{{ .ArtifactName }}.sum'
+  algorithm: sha256
+  split: true
+dockers:
+  - goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    image_templates:
+      - newrelic/nrdot-collector-host:{{ .Version }}-amd64
+      - newrelic/nrdot-collector-host:latest-amd64
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+  - goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    image_templates:
+      - newrelic/nrdot-collector-host:{{ .Version }}-arm64
+      - newrelic/nrdot-collector-host:latest-arm64
+    extra_files:
+      - config.yaml
+    build_flag_templates:
+      - --pull
+      - --platform=linux/arm64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.name={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
+      - --label=org.opencontainers.image.source={{.GitURL}}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+    use: buildx
+docker_manifests:
+  - name_template: newrelic/nrdot-collector-host:{{ .Version }}
+    image_templates:
+      - newrelic/nrdot-collector-host:{{ .Version }}-amd64
+      - newrelic/nrdot-collector-host:{{ .Version }}-arm64
+  - name_template: newrelic/nrdot-collector-host:latest
+    image_templates:
+      - newrelic/nrdot-collector-host:latest-amd64
+      - newrelic/nrdot-collector-host:latest-arm64
+blobs:
+  - bucket: nr-releases
+    provider: s3
+    region: us-east-1
+    directory: nrdot-collector-releases/nrdot-collector-host/{{ .Version }}
+changelog:
+  disable: "true"
+signs:
+  - args:
+      - --batch
+      - -u
+      - '{{ .Env.GPG_FINGERPRINT }}'
+      - --output
+      - ${signature}
+      - --detach-sign
+      - ${artifact}
+    signature: ${artifact}.sig
+    artifacts: all
+    certificate: ${artifact}.pem
+docker_signs:
+  - args:
+      - sign
+      - ${artifact}
+    artifacts: all

--- a/distributions/nrdot-collector-host/Dockerfile
+++ b/distributions/nrdot-collector-host/Dockerfile
@@ -1,9 +1,7 @@
-FROM alpine:3.18 as certs
+FROM alpine:3.21 as certs
 RUN apk --update add ca-certificates
 
-FROM alpine:3.18
-
-RUN apk add --no-cache bash
+FROM scratch
 
 ARG USER_UID=10001
 USER ${USER_UID}

--- a/distributions/nrdot-collector-host/Dockerfile
+++ b/distributions/nrdot-collector-host/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.18 as certs
+RUN apk --update add ca-certificates
+
+FROM alpine:3.18
+
+RUN apk add --no-cache bash
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --chmod=755 nrdot-collector-host /nrdot-collector-host
+COPY config.yaml /etc/nrdot-collector-host/config.yaml
+ENTRYPOINT ["/nrdot-collector-host"]
+CMD ["--config", "/etc/nrdot-collector-host/config.yaml"]
+# `4137` and `4318`: OTLP
+EXPOSE 4317 4318

--- a/distributions/nrdot-collector-host/README.md
+++ b/distributions/nrdot-collector-host/README.md
@@ -1,0 +1,7 @@
+# nrdot-collector-host
+
+Note: See [general README](../README.md) for information that applies to all distributions.
+
+A distribution of the NRDOT collector focused on
+- monitoring the host the collector is deployed on via `hostmetricsreceiver` and `filelogreceiver`
+- support piping other telemetry through it via the `otlpreceiver`

--- a/distributions/nrdot-collector-host/THIRD_PARTY_NOTICES.md
+++ b/distributions/nrdot-collector-host/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,247 @@
+# Third Party Notices
+
+The New Relic infrastructure agent uses source code from third party libraries which carry their own copyright notices
+and license terms. These notices are provided below.
+
+In the event that a required notice is missing or incorrect, please notify us by e-mailing
+[open-source@newrelic.com](mailto:open-source@newrelic.com).
+
+For any licenses that require the disclosure of source code, the source code
+can be found at https://github.com/newrelic/opentelemetry-collector-releases.
+
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/component](https://go.opentelemetry.io/collector/component)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/confmap](https://go.opentelemetry.io/collector/confmap)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/confmap/provider/envprovider](https://go.opentelemetry.io/collector/confmap/provider/envprovider)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/confmap/provider/fileprovider](https://go.opentelemetry.io/collector/confmap/provider/fileprovider)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/confmap/provider/httpprovider](https://go.opentelemetry.io/collector/confmap/provider/httpprovider)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/confmap/provider/httpsprovider](https://go.opentelemetry.io/collector/confmap/provider/httpsprovider)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/confmap/provider/yamlprovider](https://go.opentelemetry.io/collector/confmap/provider/yamlprovider)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/connector](https://go.opentelemetry.io/collector/connector)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/exporter](https://go.opentelemetry.io/collector/exporter)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/exporter/debugexporter](https://go.opentelemetry.io/collector/exporter/debugexporter)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/exporter/otlpexporter](https://go.opentelemetry.io/collector/exporter/otlpexporter)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/exporter/otlphttpexporter](https://go.opentelemetry.io/collector/exporter/otlphttpexporter)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/extension](https://go.opentelemetry.io/collector/extension)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/otelcol](https://go.opentelemetry.io/collector/otelcol)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/processor](https://go.opentelemetry.io/collector/processor)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/processor/batchprocessor](https://go.opentelemetry.io/collector/processor/batchprocessor)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/processor/memorylimiterprocessor](https://go.opentelemetry.io/collector/processor/memorylimiterprocessor)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/receiver](https://go.opentelemetry.io/collector/receiver)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [go.opentelemetry.io/collector/receiver/otlpreceiver](https://go.opentelemetry.io/collector/receiver/otlpreceiver)
+
+Distributed under the following license(s):
+
+* Apache-2.0
+
+
+
+## [golang.org/x/sys](https://golang.org/x/sys)
+
+Distributed under the following license(s):
+
+* BSD-3-Clause
+
+
+
+

--- a/distributions/nrdot-collector-host/config.yaml
+++ b/distributions/nrdot-collector-host/config.yaml
@@ -1,12 +1,3 @@
-# The following environment variables require manual modification:
-# - NEW_RELIC_LICENSE_KEY: New Relic ingest key.
-
-# If the collector is not installed through a package manager, the following
-# environment variables need to be set:
-# - NEW_RELIC_MEMORY_LIMIT_MIB: Maximum amount of memory to be used. (default: 100)
-# - OTEL_EXPORTER_OTLP_ENDPOINT: New Relic OTLP endpoint to export metrics to (see: https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)
-
-# Keep host monitoring configuration in sync with: https://github.com/newrelic/newrelic-opentelemetry-examples/blob/main/other-examples/collector/host-monitoring/k8s/collector.yaml
 extensions:
   health_check:
 

--- a/distributions/nrdot-collector-host/manifest.yaml
+++ b/distributions/nrdot-collector-host/manifest.yaml
@@ -1,16 +1,13 @@
 dist:
-  module: github.com/newrelic/opentelemetry-collector-releases/nrdot-collector-k8s
-  name: nrdot-collector-k8s
+  module: github.com/newrelic/opentelemetry-collector-releases/nrdot-collector-host
+  name: nrdot-collector-host
   description: New Relic OpenTelemetry Collector
-  version: 0.8.9
+  version: 0.8.10
   output_path: ./_build
 
 receivers:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.118.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.118.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.118.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.118.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver v0.118.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.118.0
 
 processors:
@@ -18,16 +15,12 @@ processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.118.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor v0.118.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.118.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.118.0
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.118.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.118.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.118.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.118.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.118.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.118.0
 
 exporters:
-  # shared
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.118.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.118.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.118.0
@@ -44,12 +37,8 @@ providers:
 
 # When adding a replace, add a comment before it to document why it's needed and when it can be removed
 replaces:
-  ### Transitive deps determined via `go mod graph | grep $dep@$dep_replace_version`
-  # Why: Fixes CVE-2024-41110
-  # Transitive dep of: prometheusreceiver
-  - github.com/docker/docker v27.0.3+incompatible => github.com/docker/docker v27.3.1+incompatible
   # Why: Fixes CVE-2024-45337
-  # Transitive dep of: x/net, hostmetricsreceiver, prometheusreceiver
+  # Transitive dep of: x/net, hostmetricsreceiver
   - golang.org/x/crypto v0.28.0 => golang.org/x/crypto v0.31.0
   # Why: Fixes CVE-2024-45338
   # Transitive dep of: almost all components

--- a/distributions/nrdot-collector-host/nrdot-collector-host.conf
+++ b/distributions/nrdot-collector-host/nrdot-collector-host.conf
@@ -1,0 +1,12 @@
+# Systemd environment file for the nrdot-collector-host service
+
+# New Relic default variables
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net:4317
+NEW_RELIC_MEMORY_LIMIT_MIB=100
+
+# Command-line options for the nrdot-collector-host service.
+# Run `/usr/bin/nrdot-collector-host --help` to see all available options.
+#
+# pkg.translator.prometheus.NormalizeName feature-gate is disabled by default to avoid altering prometheus metrics
+# names when reported through non-prometheus exporters.
+OTELCOL_OPTIONS="--config=/etc/nrdot-collector-host/config.yaml"

--- a/distributions/nrdot-collector-host/nrdot-collector-host.service
+++ b/distributions/nrdot-collector-host/nrdot-collector-host.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=NRDOT Collector Host
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/nrdot-collector-host/nrdot-collector-host.conf
+ExecStart=/usr/bin/nrdot-collector-host $OTELCOL_OPTIONS
+KillMode=mixed
+Restart=on-failure
+Type=simple
+User=nrdot-collector-host
+Group=nrdot-collector-host
+
+[Install]
+WantedBy=multi-user.target

--- a/distributions/nrdot-collector-host/postinstall.sh
+++ b/distributions/nrdot-collector-host/postinstall.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if command -v systemctl >/dev/null 2>&1; then
+    if [ "${NRDOT_MODE}" = "ROOT" ]; then
+        sed -i "/User=nrdot-collector-host/d" /lib/systemd/system/nrdot-collector-host.service
+        sed -i "/Group=nrdot-collector-host/d" /lib/systemd/system/nrdot-collector-host.service
+    fi
+    systemctl enable nrdot-collector-host.service
+    if [ -f /etc/nrdot-collector-host/config.yaml ]; then
+        systemctl start nrdot-collector-host.service
+    fi
+fi

--- a/distributions/nrdot-collector-host/preinstall.sh
+++ b/distributions/nrdot-collector-host/preinstall.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create the user if NRDOT_MODE is not set to root
+if [ "${NRDOT_MODE}" != "ROOT" ]; then
+  getent passwd nrdot-collector-host >/dev/null || useradd --system --user-group --no-create-home --shell /sbin/nologin nrdot-collector-host
+fi

--- a/distributions/nrdot-collector-host/preremove.sh
+++ b/distributions/nrdot-collector-host/preremove.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl stop nrdot-collector-host.service
+    systemctl disable nrdot-collector-host.service
+fi

--- a/distributions/nrdot-collector-host/test-spec.yaml
+++ b/distributions/nrdot-collector-host/test-spec.yaml
@@ -1,0 +1,3 @@
+nightly:
+  ec2:
+    enabled: true

--- a/test/terraform/permanent/main.tf
+++ b/test/terraform/permanent/main.tf
@@ -1,6 +1,6 @@
 locals {
   distros = toset(distinct(flatten([
-    for _, v in fileset(path.module, "../../../distributions/**") :
+    for _, v in fileset(path.module, "../../../distributions/*/**") :
     regex("../../../distributions/([^/]*).*", dirname(v))
   ])))
   test_specs = {

--- a/test/terraform/permanent/outputs.tf
+++ b/test/terraform/permanent/outputs.tf
@@ -1,3 +1,7 @@
 output "ecr_repository_urls" {
   value = [for key, value in module.ecr : value.repository_url]
 }
+
+output "distros" {
+  value = local.distros
+}


### PR DESCRIPTION
### Summary
- Added host distro named `nrdot-collector-host`. Files are copied from `nr-otel-collector` and modified as necessary:
  - Removed feature gate (`--feature-gates=-pkg.translator.prometheus.NormalizeName`) from default args (Dockerfile and `.conf` file) as distro does not contain [prometheus-related components](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/prometheus/README.md#full-normalization)
  - Removed ports `55678` and `55679` from docker `EXPOSE` as they are related to [OpenCensus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/opencensusreceiver#getting-started) which we do not use
  - Bumped provider versions to `1.24.0` to match component version of `0.118.0` (see [otel release notes](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.118.0))
    - Added missing providers to k8s manifest
- Rearranged/added README content to support multiple distros
