### PR TITLE
ci: revert normalizing host.name in query

### DIFF
--- a/test/e2e/util/test/hostname.go
+++ b/test/e2e/util/test/hostname.go
@@ -11,18 +11,13 @@ const (
 )
 
 func NewHostNamePrefix(envName string, deployId string, hostType string) string {
-	distro := getNormalizedDistro()
+	distro := envutil.GetDistro()
 	// only a prefix as helm chart appends hostId
 	return strings.Join([]string{envName, deployId, distro, hostType}, hostNameSegmentSeparator)
 }
 
 func NewNrQueryHostNamePattern(envName string, deployId string, hostType string) string {
-	distro := getNormalizedDistro()
+	distro := envutil.GetDistro()
 	hostId := Wildcard
 	return strings.Join([]string{envName, deployId, distro, hostType, hostId}, hostNameSegmentSeparator)
-}
-
-func getNormalizedDistro() string {
-	// solely to improve readability - no technical necessity
-	return strings.Replace(envutil.GetDistro(), hostNameSegmentSeparator, "_", -1)
 }


### PR DESCRIPTION
### Summary
- Reverting the 'normalization' of the distro in the host name as it causes nightly to fail. I initially thought it would be worth for readability but it also forces normalizing it in terraform which just becomes cumbersome to remember. If readability becomes an issue, adopting a different separator than `-` might be preferable than trying to shoehorn all segments that naturally contain hyphens into using a different character.