### PR TITLE
feat: add distro to user agent

### DIFF
--- a/distributions/nr-otel-collector/manifest.yaml
+++ b/distributions/nr-otel-collector/manifest.yaml
@@ -1,7 +1,7 @@
 dist:
   module: github.com/newrelic/opentelemetry-collector-releases/nr-otel-collector
   name: nr-otel-collector
-  description: New Relic OpenTelemetry Collector
+  description: NRDOT Collector Legacy
   version: 0.8.10
   output_path: ./_build
 

--- a/distributions/nr-otel-collector/nr-otel-collector.service
+++ b/distributions/nr-otel-collector/nr-otel-collector.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=New Relic OpenTelemetry Collector
+Description=NRDOT Collector Legacy
 After=network.target
 
 [Service]

--- a/distributions/nrdot-collector-host/manifest.yaml
+++ b/distributions/nrdot-collector-host/manifest.yaml
@@ -1,7 +1,7 @@
 dist:
   module: github.com/newrelic/opentelemetry-collector-releases/nrdot-collector-host
   name: nrdot-collector-host
-  description: New Relic OpenTelemetry Collector
+  description: NRDOT Collector Host
   version: 0.8.10
   output_path: ./_build
 

--- a/distributions/nrdot-collector-k8s/manifest.yaml
+++ b/distributions/nrdot-collector-k8s/manifest.yaml
@@ -1,7 +1,7 @@
 dist:
   module: github.com/newrelic/opentelemetry-collector-releases/nrdot-collector-k8s
   name: nrdot-collector-k8s
-  description: New Relic OpenTelemetry Collector
+  description: NRDOT Collector k8s
   version: 0.8.9
   output_path: ./_build
 


### PR DESCRIPTION
### Summary
- It appears that the `description` field gets incorporated into the user agent header (instead of the `name`) that the collector adds when sending telemetry to NR.  In order to allow facetting ingest data by distro, we should ensure that the description also contains the distro name. I chose an arbitrary distro name `Legacy` for `nr-otel-collector` so that we can use a single pattern to parse the distro.