### PR TITLE
fix: Update s3 bucket name

### DIFF
--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -134,7 +134,7 @@ resource "aws_instance" "ubuntu" {
               curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
               unzip -q awscliv2.zip
               ./aws/install
-              deb_package_basepath='s3://${var.releases_bucket_name}/opentelemetry-collector-releases/${var.collector_version}/'
+              deb_package_basepath='s3://${var.releases_bucket_name}/nrdot-collector-releases/${var.collector_version}/'
               latest_deb_package_filename=$(aws s3 ls $${deb_package_basepath} | sort -r | grep '${var.collector_distro}' | grep 'amd64.deb$' | head -n1 | awk '{print $NF}')
               echo "Installing collector from: $${deb_package_basepath}$${latest_deb_package_filename}"
               aws s3 cp "$${deb_package_basepath}$${latest_deb_package_filename}" /tmp/collector.deb


### PR DESCRIPTION
Updates the ec2 test instances to pull from the `nrdot-collector-releases` base key