### PR TITLE
fix: add missing distro folder/namespace to s3 path

### DIFF
--- a/test/terraform/modules/ec2/main.tf
+++ b/test/terraform/modules/ec2/main.tf
@@ -137,7 +137,7 @@ resource "aws_instance" "ubuntu" {
               curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
               unzip -q awscliv2.zip
               ./aws/install
-              deb_package_basepath='s3://${var.releases_bucket_name}/nrdot-collector-releases/${var.collector_version}/'
+              deb_package_basepath='s3://${var.releases_bucket_name}/nrdot-collector-releases/${var.collector_distro}/${var.collector_version}/'
               latest_deb_package_filename=$(aws s3 ls $${deb_package_basepath} | sort -r | grep '${var.collector_distro}' | grep 'amd64.deb$' | head -n1 | awk '{print $NF}')
               echo "Installing collector from: $${deb_package_basepath}$${latest_deb_package_filename}"
               aws s3 cp "$${deb_package_basepath}$${latest_deb_package_filename}" /tmp/collector.deb


### PR DESCRIPTION
### Summary
- Incorporate [missing distro name](https://github.com/newrelic/opentelemetry-collector-releases/blob/50b9f03b0430803fce4e726a9463dc6d2d8c2f46/distributions/nrdot-collector-host/.goreleaser-nightly.yaml#L121) into s3 path when querying for binaries in EC2 on startup